### PR TITLE
Removes possibly-unnecessary atomics.

### DIFF
--- a/Simulation/obscuro/pobi.go
+++ b/Simulation/obscuro/pobi.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/google/uuid"
 	"simulation/common"
-	"sync/atomic"
 )
 
 // called when a new L1 block was mined
@@ -21,7 +20,7 @@ func (a Node) newPobiRound(b common.Block, doneCh *chan bool) {
 	// wait to receive rollups From peers
 	// todo - make this smarter. e.g: if 90% of the peers have sent rollups, proceed. Or if a Nonce is very low and probabilistically there is no chance, etc
 	common.ScheduleInterrupt(a.cfg.GossipPeriod, doneCh, func() {
-		if atomic.LoadInt32(a.interrupt) == 1 {
+		if a.interrupt == 1 {
 			return
 		}
 

--- a/Simulation/simulation/l1_network.go
+++ b/Simulation/simulation/l1_network.go
@@ -3,7 +3,6 @@ package simulation
 import (
 	"simulation/common"
 	"simulation/ethereum-mock"
-	"sync/atomic"
 	"time"
 )
 
@@ -14,12 +13,12 @@ type L1NetworkCfg struct {
 	Stats *Stats
 	// used as a signal to stop all network communication.
 	// This helps prevent deadlocks when stopping nodes
-	interrupt *int32
+	interrupt int32
 }
 
 // BroadcastBlock broadcast a block to the l1 nodes
 func (n *L1NetworkCfg) BroadcastBlock(b common.EncodedBlock) {
-	if atomic.LoadInt32(n.interrupt) == 1 {
+	if n.interrupt == 1 {
 		return
 	}
 	bl, _ := b.Decode()
@@ -34,7 +33,7 @@ func (n *L1NetworkCfg) BroadcastBlock(b common.EncodedBlock) {
 
 // BroadcastTx Broadcasts the L1 tx containing the rollup to the L1 network
 func (n *L1NetworkCfg) BroadcastTx(tx common.EncodedL1Tx) {
-	if atomic.LoadInt32(n.interrupt) == 1 {
+	if n.interrupt == 1 {
 		return
 	}
 	for _, m := range n.nodes {
@@ -62,7 +61,7 @@ func (n *L1NetworkCfg) Start(delay time.Duration) {
 	}
 }
 func (n *L1NetworkCfg) Stop() {
-	atomic.StoreInt32(n.interrupt, 1)
+	n.interrupt = 1
 	for _, m := range n.nodes {
 		t := m
 		go t.Stop()

--- a/Simulation/simulation/simulation.go
+++ b/Simulation/simulation/simulation.go
@@ -22,7 +22,7 @@ func RunSimulation(nrWallets int, nrNodes int, simulationTime int, avgBlockDurat
 
 	l1Network := L1NetworkCfg{delay: func() uint64 {
 		return common.RndBtw(uint64(avgLatency/10), uint64(2*avgLatency))
-	}, Stats: &stats, interrupt: new(int32)}
+	}, Stats: &stats, interrupt: 0}
 	l1Cfg := ethereum_mock.MiningConfig{PowTime: func() uint64 {
 		// This formula might feel counter-intuitive, but it is a good approximation for Proof of Work.
 		// It creates a uniform distribution up to nrMiners*avgDuration


### PR DESCRIPTION
Not 100% on this, I know you pushed back before.

But in my understanding, since:

* The interrupt is initialised when the node is created, to `0`
* The interrupt is only ever flipped to `1` - no one ever tries to set it to anything else, or tries to set it back to zero

The atomicity is not required, despite the use of goroutines. Atomicity is required e.g. when incrementing a number repeatedly, and some increments will occur at the same time and be lost. It's not clear what could be lost in the case of two competing updates here, since both would be trying to set the interrupt to `1` anyway.