### PR TITLE
Fix race condition and remove ethereum_mock dependency

### DIFF
--- a/go/common/common.go
+++ b/go/common/common.go
@@ -29,3 +29,13 @@ type (
 type Nonce = uint64
 
 type EncodedRollup []byte
+
+type NotifyNewBlock interface {
+	RPCNewHead(b EncodedBlock, p EncodedBlock)
+	RPCNewFork(b []EncodedBlock)
+}
+
+type L1Node interface {
+	RPCBlockchainFeed() []*Block
+	BroadcastTx(t EncodedL1Tx)
+}

--- a/go/common/l1_types.go
+++ b/go/common/l1_types.go
@@ -188,7 +188,7 @@ func (b *Block) Height(resolver BlockResolver) int {
 
 	p, f := b.Parent(resolver)
 	if !f {
-		panic("wtf")
+		panic(fmt.Sprintf("Could not find parent of block b_%s", b.Hash()))
 	}
 
 	v := p.Height(resolver) + 1

--- a/go/obscuronode/enclave/db.go
+++ b/go/obscuronode/enclave/db.go
@@ -174,7 +174,7 @@ func (db *inMemoryDB) FetchTxs() []L2Tx {
 func (db *inMemoryDB) PruneTxs(toRemove map[common2.TxHash]common2.TxHash) {
 	db.mpMutex.Lock()
 	defer db.mpMutex.Unlock()
-	r := make(map[common2.TxHash]L2Tx, 0)
+	r := make(map[common2.TxHash]L2Tx)
 	for id, t := range db.mempool {
 		_, f := toRemove[id]
 		if !f {

--- a/go/obscuronode/enclave/db.go
+++ b/go/obscuronode/enclave/db.go
@@ -1,6 +1,7 @@
 package enclave
 
 import (
+	"fmt"
 	"sync"
 
 	common2 "github.com/obscuronet/obscuro-playground/go/common"
@@ -18,6 +19,7 @@ type DB interface {
 	FetchState(hash common2.L1RootHash) (BlockState, bool)
 	SetState(hash common2.L1RootHash, state BlockState)
 	FetchRollup(hash common2.L2RootHash) *Rollup
+	ExistRollup(hash common2.L2RootHash) bool
 	FetchRollupState(hash common2.L2RootHash) State
 	SetRollupState(hash common2.L2RootHash, state State)
 	Head() BlockState
@@ -126,9 +128,16 @@ func (db *inMemoryDB) FetchRollup(hash common2.L2RootHash) *Rollup {
 	defer db.stateMutex.RUnlock()
 	r, f := db.rollups[hash]
 	if !f {
-		panic("wtf")
+		panic(fmt.Sprintf("Could not find rollup: r_%s", hash))
 	}
 	return r
+}
+
+func (db *inMemoryDB) ExistRollup(hash common2.L2RootHash) bool {
+	db.stateMutex.RLock()
+	defer db.stateMutex.RUnlock()
+	_, f := db.rollups[hash]
+	return f
 }
 
 func (db *inMemoryDB) FetchRollups(height int) []*Rollup {

--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -28,8 +28,10 @@ type Enclave interface {
 	IngestBlocks(blocks []common3.ExtBlock)
 	Start(block common3.ExtBlock)
 
-	// SubmitBlock - When a new round starts, the host submits a block to the enclave, which responds with a rollup
-	// it is the responsibility of the host to gossip the rollup
+	// SubmitBlock - When a new POBI round starts, the host submits a block to the enclave, which responds with a rollup
+	// it is the responsibility of the host to gossip the returned rollup
+	// For good functioning the caller should always submit blocks ordered by height
+	// submitting a block before receiving a parent of it, will result in it being ignored
 	SubmitBlock(block common3.ExtBlock) SubmitBlockResponse
 
 	// SubmitRollup - receive gossiped rollups
@@ -98,8 +100,8 @@ func (e *enclaveImpl) Start(block common3.ExtBlock) {
 			currentState = executeTransactions(currentProcessedTxs, currentState)
 
 		case tx := <-e.txCh:
-			_, f := currentProcessedTxsMap[tx.ID]
-			if !f {
+			_, found := currentProcessedTxsMap[tx.ID]
+			if !found {
 				currentProcessedTxsMap[tx.ID] = tx
 				currentProcessedTxs = append(currentProcessedTxs, tx)
 				executeTx(&currentState, tx)
@@ -140,7 +142,21 @@ func (e *enclaveImpl) IngestBlocks(blocks []common3.ExtBlock) {
 }
 
 func (e *enclaveImpl) SubmitBlock(block common3.ExtBlock) SubmitBlockResponse {
+
+	// Todo - investigate further why this is needed.
+	// So far this seems to recover correctly
+	defer func() {
+		if r := recover(); r != nil {
+			common3.Log(fmt.Sprintf("Agg%d Panic %s\n", e.node, r))
+		}
+	}()
+
 	b := block.ToBlock()
+	_, foundBlock := e.db.Resolve(b.Hash())
+	if foundBlock {
+		return SubmitBlockResponse{Processed: false}
+	}
+
 	e.db.Store(b)
 	// this is where much more will actually happen.
 	// the "blockchain" logic from geth has to be executed here,
@@ -176,7 +192,10 @@ func (e *enclaveImpl) SubmitRollup(rollup common2.ExtRollup) {
 		Header:       rollup.Header,
 		Transactions: decryptTransactions(rollup.Txs),
 	}
-	e.db.StoreRollup(&r)
+	// only store if the parent exists
+	if e.db.ExistRollup(r.Header.ParentHash) {
+		e.db.StoreRollup(&r)
+	}
 }
 
 func (e *enclaveImpl) SubmitTx(tx common2.EncryptedTx) {

--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -142,7 +142,6 @@ func (e *enclaveImpl) IngestBlocks(blocks []common3.ExtBlock) {
 }
 
 func (e *enclaveImpl) SubmitBlock(block common3.ExtBlock) SubmitBlockResponse {
-
 	// Todo - investigate further why this is needed.
 	// So far this seems to recover correctly
 	defer func() {

--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -194,6 +194,8 @@ func (e *enclaveImpl) SubmitRollup(rollup common2.ExtRollup) {
 	// only store if the parent exists
 	if e.db.ExistRollup(r.Header.ParentHash) {
 		e.db.StoreRollup(&r)
+	} else {
+		common3.Log(fmt.Sprintf("Agg%d:> Received rollup with no parent: r_%s\n", e.node, r.Hash()))
 	}
 }
 

--- a/go/obscuronode/node.go
+++ b/go/obscuronode/node.go
@@ -121,6 +121,7 @@ func sendInterrupt(interrupt *int32) *int32 {
 func (a *Node) processBlocks(blocks []common.EncodedBlock, interrupt *int32) {
 	var result enclave.SubmitBlockResponse
 	for _, block := range blocks {
+		// For the genesis block the parent is nil
 		if block != nil {
 			result = a.Enclave.SubmitBlock(block.DecodeBlock().ToExtBlock())
 		}

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -14,11 +14,6 @@ type L1Network interface {
 	BroadcastTx(tx common2.EncodedL1Tx)
 }
 
-type NotifyNewBlock interface {
-	RPCNewHead(b common2.EncodedBlock)
-	RPCNewFork(b []common2.EncodedBlock)
-}
-
 type MiningConfig struct {
 	PowTime common2.Latency
 }
@@ -36,7 +31,7 @@ type StatsCollector interface {
 type Node struct {
 	ID       common2.NodeID
 	cfg      MiningConfig
-	clients  []NotifyNewBlock
+	clients  []common2.NotifyNewBlock
 	network  L1Network
 	mining   bool
 	stats    StatsCollector
@@ -61,6 +56,7 @@ type Node struct {
 // Start runs an infinite loop that listens to the two block producing channels and processes them.
 // it outputs the winning blocks to the roundWinnerCh channel
 func (m *Node) Start() {
+	//common2.Log(fmt.Sprintf("Starting miner %d..", m.ID))
 	if m.mining {
 		// This starts the mining
 		go m.startMining()
@@ -79,10 +75,12 @@ func (m *Node) Start() {
 			}
 
 		case mb := <-m.miningCh: // Received from the local mining
-			m.Resolver.Store(mb)
-			if mb.Height(m.Resolver) > head.Height(m.Resolver) { // Ignore the locally produced block if someone else found one already
-				head = m.setHead(mb)
-				p, _ := mb.Parent(m.Resolver)
+			head = m.processBlock(mb, head)
+			if head.Hash() == mb.Hash() { // Ignore the locally produced block if someone else found one already
+				p, found := mb.Parent(m.Resolver)
+				if !found {
+					panic("noo")
+				}
 				m.network.BroadcastBlock(mb.EncodeBlock(), p.EncodeBlock())
 			}
 		case <-m.headInCh:
@@ -96,26 +94,31 @@ func (m *Node) Start() {
 func (m *Node) processBlock(b *common2.Block, head *common2.Block) *common2.Block {
 	m.Resolver.Store(b)
 	_, f := m.Resolver.Resolve(b.Header.ParentHash)
+
 	// only proceed if the parent is available
-	// todo review this nested ifs
-	// nolint:nestif
-	if f {
-		if b.Height(m.Resolver) > head.Height(m.Resolver) {
-			// Check for Reorgs
-			if !common2.IsAncestor(head, b, m.Resolver) {
-				m.stats.L1Reorg(m.ID)
-				fork := LCA(head, b, m.Resolver)
-				common2.Log(fmt.Sprintf("> M%d: L1Reorg new=b_%s(%d), old=b_%s(%d), fork=b_%s(%d)", m.ID, common2.Str(b.Hash()), b.Height(m.Resolver), common2.Str(head.Hash()), head.Height(m.Resolver), common2.Str(fork.Hash()), fork.Height(m.Resolver)))
-				head = m.setFork(BlocksBetween(fork, b, m.Resolver))
-			} else {
-				head = m.setHead(b)
-			}
-		}
-	} else {
-		common2.Log(fmt.Sprintf("> M%d: Not found=b_%s", m.ID, common2.Str(b.Header.ParentHash)))
+	if !f {
+		common2.Log(fmt.Sprintf("> M%d: Parent block not found=b_%s", m.ID, common2.Str(b.Header.ParentHash)))
+		return head
 	}
 
-	return head
+	// Ignore superseeded blocks
+	if b.Height(m.Resolver) <= head.Height(m.Resolver) {
+		return head
+	}
+
+	// Check for Reorgs
+	if !common2.IsAncestor(head, b, m.Resolver) {
+		m.stats.L1Reorg(m.ID)
+		fork := LCA(head, b, m.Resolver)
+		common2.Log(fmt.Sprintf("> M%d: L1Reorg new=b_%s(%d), old=b_%s(%d), fork=b_%s(%d)", m.ID, common2.Str(b.Hash()), b.Height(m.Resolver), common2.Str(head.Hash()), head.Height(m.Resolver), common2.Str(fork.Hash()), fork.Height(m.Resolver)))
+		return m.setFork(BlocksBetween(fork, b, m.Resolver))
+	}
+
+	if b.Height(m.Resolver) > (head.Height(m.Resolver) + 1) {
+		panic(fmt.Sprintf("> M%d: Should not happen", m.ID))
+	}
+
+	return m.setHead(b)
 }
 
 // Notifies the Miner to start mining on the new block and the aggregtor to produce rollups
@@ -127,7 +130,15 @@ func (m *Node) setHead(b *common2.Block) *common2.Block {
 	// notify the clients
 	for _, c := range m.clients {
 		t := c
-		go t.RPCNewHead(b.EncodeBlock())
+		if b.Height(m.Resolver) == 0 {
+			go t.RPCNewHead(b.EncodeBlock(), nil)
+		} else {
+			p, f := b.Parent(m.Resolver)
+			if !f {
+				panic("This should not happen")
+			}
+			go t.RPCNewHead(b.EncodeBlock(), p.EncodeBlock())
+		}
 	}
 	m.canonicalCh <- b
 
@@ -135,23 +146,23 @@ func (m *Node) setHead(b *common2.Block) *common2.Block {
 }
 
 func (m *Node) setFork(blocks []*common2.Block) *common2.Block {
-	lastKnownBlock := blocks[len(blocks)-1]
+	head := blocks[len(blocks)-1]
 	if atomic.LoadInt32(m.interrupt) == 1 {
-		return lastKnownBlock
+		return head
 	}
 
-	encoded := make([]common2.EncodedBlock, len(blocks))
+	fork := make([]common2.EncodedBlock, len(blocks))
 	for i, block := range blocks {
-		encoded[i] = block.EncodeBlock()
+		fork[i] = block.EncodeBlock()
 	}
 
 	// notify the clients
 	for _, c := range m.clients {
-		c.RPCNewFork(encoded)
+		go c.RPCNewFork(fork)
 	}
-	m.canonicalCh <- lastKnownBlock
+	m.canonicalCh <- head
 
-	return lastKnownBlock
+	return head
 }
 
 // P2PReceiveBlock is called by counterparties when there is a block to broadcast
@@ -241,7 +252,7 @@ func (m *Node) Stop() {
 func NewMiner(
 	id common2.NodeID,
 	cfg MiningConfig,
-	client NotifyNewBlock,
+	client common2.NotifyNewBlock,
 	network L1Network,
 	statsCollector StatsCollector,
 ) Node {
@@ -252,7 +263,7 @@ func NewMiner(
 		stats:        statsCollector,
 		Resolver:     NewResolver(),
 		db:           NewTxDB(),
-		clients:      []NotifyNewBlock{client},
+		clients:      []common2.NotifyNewBlock{client},
 		network:      network,
 		exitCh:       make(chan bool),
 		exitMiningCh: make(chan bool),

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -56,7 +56,7 @@ type Node struct {
 // Start runs an infinite loop that listens to the two block producing channels and processes them.
 // it outputs the winning blocks to the roundWinnerCh channel
 func (m *Node) Start() {
-	//common2.Log(fmt.Sprintf("Starting miner %d..", m.ID))
+	// common2.Log(fmt.Sprintf("Starting miner %d..", m.ID))
 	if m.mining {
 		// This starts the mining
 		go m.startMining()

--- a/integration/simulation/transaction_manager.go
+++ b/integration/simulation/transaction_manager.go
@@ -1,0 +1,1 @@
+package simulation


### PR DESCRIPTION
major changes:

1. Remove dependency on ethereum_mock.
2. Submit both the current L1 block and the parent on the RPC call to the l2 node. 

