### PR TITLE
added output stats

### DIFF
--- a/integration/simulation/output_stats.go
+++ b/integration/simulation/output_stats.go
@@ -1,0 +1,103 @@
+package simulation
+
+import (
+	"fmt"
+
+	"github.com/obscuronet/obscuro-playground/go/common"
+	obscuroCommon "github.com/obscuronet/obscuro-playground/go/obscuronode/common"
+)
+
+// OutputStats decouples the processing of data and the collection of statistics
+// there's a bit more to do around this, this serves as a first iteration
+type OutputStats struct {
+	simulation *Simulation
+
+	l2RollupCountInHeaders    int // Number of rollups counted while node rollup header traversing
+	l2RollupCountInL1Blocks   int // Number of rollups counted while traversing the node block header and searching the txs
+	l2RollupTxCountInL1Blocks int // Number of rollup Txs counted while traversing the node block header
+	l1Height                  int // Last known l1 block height
+	l2Height                  int // Last known l2 block height
+}
+
+// NewOutputStats process the simulation and retrieves the output statistics
+func NewOutputStats(simulation *Simulation) *OutputStats {
+	outputStats := &OutputStats{
+		simulation: simulation,
+	}
+
+	outputStats.countRollups()
+	outputStats.populateHeights()
+
+	return outputStats
+}
+
+func (o *OutputStats) populateHeights() {
+	o.l1Height = int(o.simulation.l2Network.nodes[0].Headers().GetCurrentBlockHead().Height)
+	o.l2Height = int(o.simulation.l2Network.nodes[0].Headers().GetCurrentRollupHead().Height)
+}
+
+func (o *OutputStats) countRollups() {
+	l1Node := o.simulation.l1Network.nodes[0]
+	l2Node := o.simulation.l2Network.nodes[0]
+
+	// iterate the Node Headers and get the rollups
+	for header := l2Node.Headers().GetCurrentRollupHead(); header != nil; header = l2Node.Headers().GetRollupHeader(header.Parent) {
+		o.l2RollupCountInHeaders++
+	}
+
+	// iterate the L1 Blocks and get the rollups
+	for header := l2Node.Headers().GetCurrentBlockHead(); header != nil; header = l2Node.Headers().GetBlockHeader(header.Parent) {
+		block, found := l1Node.Resolver.Resolve(header.ID)
+		if !found {
+			panic("expected l1 block not found")
+		}
+		for _, tx := range block.Transactions {
+			if tx.TxType == common.RollupTx {
+				r := obscuroCommon.DecodeRollup(tx.Rollup)
+				if common.IsBlockAncestor(r.Header.L1Proof, block, l1Node.Resolver) {
+					o.l2RollupCountInL1Blocks++
+					o.l2RollupTxCountInL1Blocks += len(r.Transactions)
+				}
+			}
+		}
+	}
+}
+
+func (o *OutputStats) String() string {
+	return fmt.Sprintf("\n"+
+		"nrMiners: %d\n"+
+		"l1Height: %d\n"+
+		"l2Height: %d\n"+
+		"totalL1Blocks: %d\n"+
+		"totalL2Blocks: %d\n"+
+		"l2RollupCountInHeaders: %d\n"+
+		"l2RollupCountInL1Blocks: %d\n"+
+		"l2RollupTxCountInL1Blocks: %d\n"+
+		"maxRollupsPerBlock: %d \n"+
+		"nrEmptyBlocks: %d\n"+
+		"totalL2Txs: %d\n"+
+		"noL1Reorgs: %+v\n"+
+		"noL2Recalcs: %+v\n"+
+		"totalDepositedAmount: %d\n"+
+		"totalWithdrawnAmount: %d\n"+
+		"rollupWithMoreRecentProof: %d\n"+
+		"nrTransferTransactions: %d\n",
+		o.simulation.l1Network.Stats.nrMiners,
+		o.l1Height,
+		o.l2Height,
+		o.simulation.l1Network.Stats.totalL1Blocks,
+		o.simulation.l1Network.Stats.totalL2Blocks,
+		o.l2RollupCountInHeaders,
+		o.l2RollupCountInL1Blocks,
+		o.l2RollupTxCountInL1Blocks,
+		o.simulation.l1Network.Stats.maxRollupsPerBlock,
+		o.simulation.l1Network.Stats.nrEmptyBlocks,
+		o.simulation.l1Network.Stats.totalL2Blocks,
+		o.simulation.l1Network.Stats.noL1Reorgs,
+		o.simulation.l1Network.Stats.noL2Recalcs,
+		o.simulation.l1Network.Stats.totalDepositedAmount,
+		o.simulation.l1Network.Stats.totalWithdrawnAmount,
+		o.simulation.l1Network.Stats.rollupWithMoreRecentProof,
+		o.simulation.l1Network.Stats.nrTransferTransactions,
+	)
+}

--- a/integration/simulation/simulation_test.go
+++ b/integration/simulation/simulation_test.go
@@ -56,7 +56,8 @@ func TestSimulation(t *testing.T) {
 	// run tests
 	checkBlockchainValidity(t, txManager, simulation)
 
-	t.Logf("%+v\n", stats)
+	// generate and print the final stats
+	t.Logf("%+v\n", NewOutputStats(simulation))
 	// pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
 }
 
@@ -113,9 +114,6 @@ func validateL1L2Stats(t *testing.T, node *obscuro_node.Node, stats *Stats) {
 	if efficiency > L2ToL1EfficiencyThreshold {
 		t.Errorf("L2 to L1 Efficiency is %f. Expected:%f", efficiency, L2ToL1EfficiencyThreshold)
 	}
-
-	t.Logf("There was %d L1 blocks and %d L2 Blocks\n", stats.totalL1Blocks, stats.totalL2Blocks)
-	t.Logf("Node %d Header had %d l2 blocks in the header\n", l1HeaderCount, l2HeaderCount)
 }
 
 // validateL2TxsExist tests that all transaction in the transaction Manager are found in the blockchain state of each node


### PR DESCRIPTION
Adds a new struct that process data from both the stats and the network and prints it.

Ideally we can create a ticket to decouple the many features of the Stats struct.
Right now the Stats collects data from the mock node, the obscuro node and the tests, while also serving as test argument and end-run-summary display.

