### PR TITLE
Fixes imports of common packages. Cleans up unused common functions.

### DIFF
--- a/go/obscurocommon/block_resolver.go
+++ b/go/obscurocommon/block_resolver.go
@@ -1,4 +1,4 @@
-package common
+package obscurocommon
 
 import "github.com/ethereum/go-ethereum/core/types"
 

--- a/go/obscurocommon/common.go
+++ b/go/obscurocommon/common.go
@@ -1,4 +1,4 @@
-package common
+package obscurocommon
 
 import (
 	"github.com/ethereum/go-ethereum/common"

--- a/go/obscurocommon/encoding.go
+++ b/go/obscurocommon/encoding.go
@@ -1,4 +1,4 @@
-package common
+package obscurocommon
 
 import (
 	"github.com/ethereum/go-ethereum/core/types"

--- a/go/obscurocommon/l1_types.go
+++ b/go/obscurocommon/l1_types.go
@@ -1,4 +1,4 @@
-package common
+package obscurocommon
 
 import (
 	"math/big"

--- a/go/obscurocommon/log.go
+++ b/go/obscurocommon/log.go
@@ -1,4 +1,4 @@
-package common
+package obscurocommon
 
 import (
 	"fmt"

--- a/go/obscurocommon/utils.go
+++ b/go/obscurocommon/utils.go
@@ -1,4 +1,4 @@
-package common
+package obscurocommon
 
 import (
 	"fmt"

--- a/go/obscuronode/common/types_test.go
+++ b/go/obscuronode/common/types_test.go
@@ -1,1 +1,0 @@
-package common

--- a/go/obscuronode/enclave/crypto.go
+++ b/go/obscuronode/enclave/crypto.go
@@ -2,10 +2,10 @@ package enclave
 
 import (
 	"github.com/ethereum/go-ethereum/rlp"
-	common2 "github.com/obscuronet/obscuro-playground/go/obscuronode/common"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 )
 
-func decryptTransactions(txs common2.EncryptedTransactions) Transactions {
+func decryptTransactions(txs nodecommon.EncryptedTransactions) Transactions {
 	t := make([]L2Tx, 0)
 	for _, tx := range txs {
 		t = append(t, DecryptTx(tx))
@@ -13,7 +13,7 @@ func decryptTransactions(txs common2.EncryptedTransactions) Transactions {
 	return t
 }
 
-func DecryptTx(tx common2.EncryptedTx) L2Tx {
+func DecryptTx(tx nodecommon.EncryptedTx) L2Tx {
 	t := L2Tx{}
 	if err := rlp.DecodeBytes(tx, &t); err != nil {
 		panic("no way")
@@ -22,7 +22,7 @@ func DecryptTx(tx common2.EncryptedTx) L2Tx {
 	return t
 }
 
-func EncryptTx(tx *L2Tx) common2.EncryptedTx {
+func EncryptTx(tx *L2Tx) nodecommon.EncryptedTx {
 	bytes, err := rlp.EncodeToBytes(tx)
 	if err != nil {
 		panic("no!")
@@ -30,15 +30,15 @@ func EncryptTx(tx *L2Tx) common2.EncryptedTx {
 	return bytes
 }
 
-func encryptTransactions(transactions Transactions) common2.EncryptedTransactions {
-	result := make([]common2.EncryptedTx, 0)
+func encryptTransactions(transactions Transactions) nodecommon.EncryptedTransactions {
+	result := make([]nodecommon.EncryptedTx, 0)
 	for i := range transactions {
 		result = append(result, EncryptTx(&transactions[i]))
 	}
 	return result
 }
 
-func DecryptRollup(rollup *common2.Rollup) *Rollup {
+func DecryptRollup(rollup *nodecommon.Rollup) *Rollup {
 	return &Rollup{
 		Header:       rollup.Header,
 		Transactions: decryptTransactions(rollup.Transactions),

--- a/go/obscuronode/enclave/db.go
+++ b/go/obscuronode/enclave/db.go
@@ -6,28 +6,28 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 
-	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/obscuronet/obscuro-playground/go/common"
+	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 )
 
 // RollupResolver -database of rollups indexed by the root hash
 type RollupResolver interface {
-	FetchRollup(hash common.L2RootHash) *Rollup
+	FetchRollup(hash obscurocommon.L2RootHash) *Rollup
 	ParentRollup(r Rollup) *Rollup
 	HeightRollup(r Rollup) int
 	StoreRollup(rollup *Rollup)
-	ExistRollup(hash common.L2RootHash) bool
+	ExistRollup(hash obscurocommon.L2RootHash) bool
 }
 
 // This database lives purely in the memory space of an encrypted enclave
 type DB interface {
 	// Rollup Resolver
-	FetchRollup(hash common.L2RootHash) *Rollup
+	FetchRollup(hash obscurocommon.L2RootHash) *Rollup
 	StoreRollup(rollup *Rollup)
 	ParentRollup(*Rollup) *Rollup
 	HeightRollup(*Rollup) int
-	ExistRollup(hash common.L2RootHash) bool
+	ExistRollup(hash obscurocommon.L2RootHash) bool
 
 	// Gossip
 	FetchGossipedRollups(height int) []*Rollup
@@ -35,23 +35,23 @@ type DB interface {
 	// Block resolver
 	HeightBlock(block *types.Block) int
 	ParentBlock(block *types.Block) (*types.Block, bool)
-	ResolveBlock(hash common.L1RootHash) (*types.Block, bool)
+	ResolveBlock(hash obscurocommon.L1RootHash) (*types.Block, bool)
 	StoreBlock(node *types.Block)
 
 	// State
-	FetchState(hash common.L1RootHash) (BlockState, bool)
-	SetState(hash common.L1RootHash, state BlockState)
-	FetchRollupState(hash common.L2RootHash) State
-	SetRollupState(hash common.L2RootHash, state State)
+	FetchState(hash obscurocommon.L1RootHash) (BlockState, bool)
+	SetState(hash obscurocommon.L1RootHash, state BlockState)
+	FetchRollupState(hash obscurocommon.L2RootHash) State
+	SetRollupState(hash obscurocommon.L2RootHash, state State)
 	Head() BlockState
-	Balance(address gethcommon.Address) uint64
+	Balance(address common.Address) uint64
 
 	// Transactions
 	FetchTxs() []L2Tx
 	StoreTx(tx L2Tx)
-	PruneTxs(remove map[gethcommon.Hash]gethcommon.Hash)
-	Txs(r *Rollup) (map[gethcommon.Hash]L2Tx, bool)
-	AddTxs(*Rollup, map[gethcommon.Hash]L2Tx)
+	PruneTxs(remove map[common.Hash]common.Hash)
+	Txs(r *Rollup) (map[common.Hash]L2Tx, bool)
+	AddTxs(*Rollup, map[common.Hash]L2Tx)
 
 	// Shared secret
 	StoreSecret(secret SharedEnclaveSecret)
@@ -65,21 +65,21 @@ type blockAndHeight struct {
 
 type inMemoryDB struct {
 	// the State is dependent on the L1 block alone
-	statePerBlock  map[common.L1RootHash]BlockState
-	statePerRollup map[common.L2RootHash]State
-	headBlock      common.L1RootHash
+	statePerBlock  map[obscurocommon.L1RootHash]BlockState
+	statePerRollup map[obscurocommon.L2RootHash]State
+	headBlock      obscurocommon.L1RootHash
 	stateMutex     sync.RWMutex
 
 	rollupsByHeight map[int][]*Rollup
-	rollups         map[common.L2RootHash]*Rollup
+	rollups         map[obscurocommon.L2RootHash]*Rollup
 
-	mempool map[gethcommon.Hash]L2Tx
+	mempool map[common.Hash]L2Tx
 	mpMutex sync.RWMutex
 
-	blockCache map[common.L1RootHash]*blockAndHeight
+	blockCache map[obscurocommon.L1RootHash]*blockAndHeight
 	blockM     sync.RWMutex
 
-	transactionsPerBlockCache map[common.L2RootHash]map[gethcommon.Hash]L2Tx
+	transactionsPerBlockCache map[obscurocommon.L2RootHash]map[common.Hash]L2Tx
 	txM                       sync.RWMutex
 
 	sharedEnclaveSecret SharedEnclaveSecret
@@ -87,21 +87,21 @@ type inMemoryDB struct {
 
 func NewInMemoryDB() DB {
 	return &inMemoryDB{
-		statePerBlock:             make(map[common.L1RootHash]BlockState),
+		statePerBlock:             make(map[obscurocommon.L1RootHash]BlockState),
 		stateMutex:                sync.RWMutex{},
 		rollupsByHeight:           make(map[int][]*Rollup),
-		rollups:                   make(map[common.L2RootHash]*Rollup),
-		mempool:                   make(map[gethcommon.Hash]L2Tx),
+		rollups:                   make(map[obscurocommon.L2RootHash]*Rollup),
+		mempool:                   make(map[common.Hash]L2Tx),
 		mpMutex:                   sync.RWMutex{},
-		statePerRollup:            make(map[common.L2RootHash]State),
-		blockCache:                map[common.L1RootHash]*blockAndHeight{},
+		statePerRollup:            make(map[obscurocommon.L2RootHash]State),
+		blockCache:                map[obscurocommon.L1RootHash]*blockAndHeight{},
 		blockM:                    sync.RWMutex{},
-		transactionsPerBlockCache: make(map[common.L2RootHash]map[gethcommon.Hash]L2Tx),
+		transactionsPerBlockCache: make(map[obscurocommon.L2RootHash]map[common.Hash]L2Tx),
 		txM:                       sync.RWMutex{},
 	}
 }
 
-func (db *inMemoryDB) FetchState(hash common.L1RootHash) (BlockState, bool) {
+func (db *inMemoryDB) FetchState(hash obscurocommon.L1RootHash) (BlockState, bool) {
 	db.assertSecretAvailable()
 	db.stateMutex.RLock()
 	defer db.stateMutex.RUnlock()
@@ -109,7 +109,7 @@ func (db *inMemoryDB) FetchState(hash common.L1RootHash) (BlockState, bool) {
 	return val, found
 }
 
-func (db *inMemoryDB) SetState(hash common.L1RootHash, state BlockState) {
+func (db *inMemoryDB) SetState(hash obscurocommon.L1RootHash, state BlockState) {
 	db.assertSecretAvailable()
 	db.stateMutex.Lock()
 	defer db.stateMutex.Unlock()
@@ -124,7 +124,7 @@ func (db *inMemoryDB) SetState(hash common.L1RootHash, state BlockState) {
 	db.headBlock = hash
 }
 
-func (db *inMemoryDB) SetRollupState(hash common.L2RootHash, state State) {
+func (db *inMemoryDB) SetRollupState(hash obscurocommon.L2RootHash, state State) {
 	db.assertSecretAvailable()
 	db.stateMutex.Lock()
 	defer db.stateMutex.Unlock()
@@ -137,7 +137,7 @@ func (db *inMemoryDB) Head() BlockState {
 	return val
 }
 
-func (db *inMemoryDB) Balance(address gethcommon.Address) uint64 {
+func (db *inMemoryDB) Balance(address common.Address) uint64 {
 	db.assertSecretAvailable()
 	return db.Head().State[address]
 }
@@ -157,7 +157,7 @@ func (db *inMemoryDB) StoreRollup(rollup *Rollup) {
 	}
 }
 
-func (db *inMemoryDB) FetchRollup(hash common.L2RootHash) *Rollup {
+func (db *inMemoryDB) FetchRollup(hash obscurocommon.L2RootHash) *Rollup {
 	db.assertSecretAvailable()
 	db.stateMutex.RLock()
 	defer db.stateMutex.RUnlock()
@@ -168,7 +168,7 @@ func (db *inMemoryDB) FetchRollup(hash common.L2RootHash) *Rollup {
 	return r
 }
 
-func (db *inMemoryDB) ExistRollup(hash common.L2RootHash) bool {
+func (db *inMemoryDB) ExistRollup(hash obscurocommon.L2RootHash) bool {
 	db.assertSecretAvailable()
 	db.stateMutex.RLock()
 	defer db.stateMutex.RUnlock()
@@ -183,7 +183,7 @@ func (db *inMemoryDB) FetchGossipedRollups(height int) []*Rollup {
 	return db.rollupsByHeight[height]
 }
 
-func (db *inMemoryDB) FetchRollupState(hash common.L2RootHash) State {
+func (db *inMemoryDB) FetchRollupState(hash obscurocommon.L2RootHash) State {
 	db.assertSecretAvailable()
 	db.stateMutex.RLock()
 	defer db.stateMutex.RUnlock()
@@ -201,21 +201,18 @@ func (db *inMemoryDB) FetchTxs() []L2Tx {
 	db.assertSecretAvailable()
 	db.mpMutex.RLock()
 	defer db.mpMutex.RUnlock()
-	// txStr := make([]nodegethcommon.TxHash, 0)
 	mpCopy := make([]L2Tx, 0)
 	for _, tx := range db.mempool {
 		mpCopy = append(mpCopy, tx)
-		// txStr = append(txStr, tx.ID)
 	}
-	// nodegethcommon.Log(fmt.Sprintf(">>> %v <<<", txStr))
 	return mpCopy
 }
 
-func (db *inMemoryDB) PruneTxs(toRemove map[gethcommon.Hash]gethcommon.Hash) {
+func (db *inMemoryDB) PruneTxs(toRemove map[common.Hash]common.Hash) {
 	db.assertSecretAvailable()
 	db.mpMutex.Lock()
 	defer db.mpMutex.Unlock()
-	r := make(map[gethcommon.Hash]L2Tx)
+	r := make(map[common.Hash]L2Tx)
 	for id, t := range db.mempool {
 		_, f := toRemove[id]
 		if !f {
@@ -231,7 +228,7 @@ func (db *inMemoryDB) StoreBlock(b *types.Block) {
 	db.blockM.Lock()
 	defer db.blockM.Unlock()
 
-	if b.ParentHash() == common.GenesisHash {
+	if b.ParentHash() == obscurocommon.GenesisHash {
 		db.blockCache[b.Hash()] = &blockAndHeight{b, 0}
 		return
 	}
@@ -243,7 +240,7 @@ func (db *inMemoryDB) StoreBlock(b *types.Block) {
 	db.blockCache[b.Hash()] = &blockAndHeight{b: b, height: p.height + 1}
 }
 
-func (db *inMemoryDB) ResolveBlock(hash common.L1RootHash) (*types.Block, bool) {
+func (db *inMemoryDB) ResolveBlock(hash obscurocommon.L1RootHash) (*types.Block, bool) {
 	db.assertSecretAvailable()
 	db.blockM.RLock()
 	defer db.blockM.RUnlock()
@@ -255,7 +252,7 @@ func (db *inMemoryDB) ResolveBlock(hash common.L1RootHash) (*types.Block, bool) 
 	return block, f
 }
 
-func (db *inMemoryDB) Txs(r *Rollup) (map[gethcommon.Hash]L2Tx, bool) {
+func (db *inMemoryDB) Txs(r *Rollup) (map[common.Hash]L2Tx, bool) {
 	db.assertSecretAvailable()
 	db.txM.RLock()
 	val, found := db.transactionsPerBlockCache[r.Hash()]
@@ -263,7 +260,7 @@ func (db *inMemoryDB) Txs(r *Rollup) (map[gethcommon.Hash]L2Tx, bool) {
 	return val, found
 }
 
-func (db *inMemoryDB) AddTxs(r *Rollup, newMap map[gethcommon.Hash]L2Tx) {
+func (db *inMemoryDB) AddTxs(r *Rollup, newMap map[common.Hash]L2Tx) {
 	db.assertSecretAvailable()
 	db.txM.Lock()
 	db.transactionsPerBlockCache[r.Hash()] = newMap
@@ -281,8 +278,8 @@ func (db *inMemoryDB) HeightRollup(r *Rollup) int {
 		return height.(int)
 	}
 	if r.Hash() == GenesisRollup.Hash() {
-		r.Height.Store(common.L2GenesisHeight)
-		return common.L2GenesisHeight
+		r.Height.Store(obscurocommon.L2GenesisHeight)
+		return obscurocommon.L2GenesisHeight
 	}
 	v := db.HeightRollup(db.ParentRollup(r)) + 1
 	r.Height.Store(v)

--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -156,7 +156,7 @@ func (e *enclaveImpl) Start(block types.Block) {
 func (e *enclaveImpl) ProduceGenesis() SubmitBlockResponse {
 	return SubmitBlockResponse{
 		L2Hash:         GenesisRollup.Header.Hash(),
-		L1Hash:         GenesisHash,
+		L1Hash:         obscurocommon.GenesisHash,
 		ProducedRollup: GenesisRollup.ToExtRollup(),
 		IngestedBlock:  true,
 	}

--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -3,8 +3,9 @@ package enclave
 import (
 	"crypto/rand"
 	"fmt"
-	"github.com/obscuronet/obscuro-playground/go/log"
 	"math/big"
+
+	"github.com/obscuronet/obscuro-playground/go/log"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"

--- a/go/obscuronode/enclave/state.go
+++ b/go/obscuronode/enclave/state.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 
-	gethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/obscuronet/obscuro-playground/go/common"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 )
 
-type State = map[gethcommon.Address]uint64
+type State = map[common.Address]uint64
 
 // BlockState - Represents the state after an L1 block was processed.
 type BlockState struct {
@@ -97,7 +97,7 @@ func emptyState() State {
 
 // Determine the new canonical L2 head and calculate the State
 // Uses cache-ing to map the Head rollup and the State to each L1Node block.
-func updateState(b *types.Block, db DB, blockResolver common.BlockResolver) BlockState {
+func updateState(b *types.Block, db DB, blockResolver obscurocommon.BlockResolver) BlockState {
 	// This method is called recursively in case of Re-orgs. Stop when state was calculated already.
 	val, found := db.FetchState(b.Hash())
 	if found {
@@ -105,7 +105,7 @@ func updateState(b *types.Block, db DB, blockResolver common.BlockResolver) Bloc
 	}
 
 	// The genesis rollup is part of the canonical chain and will be included in an L1 block by the first Aggregator.
-	if b.Hash() == common.GenesisBlock.Hash() {
+	if b.Hash() == obscurocommon.GenesisBlock.Hash() {
 		bs := BlockState{
 			Block:          b,
 			Head:           &GenesisRollup,
@@ -139,7 +139,7 @@ func currentTxs(head *Rollup, mempool []L2Tx, db DB) []L2Tx {
 	return findTxsNotIncluded(head, mempool, db)
 }
 
-func FindWinner(parent *Rollup, rollups []*Rollup, db DB, blockResolver common.BlockResolver) (*Rollup, bool) {
+func FindWinner(parent *Rollup, rollups []*Rollup, db DB, blockResolver obscurocommon.BlockResolver) (*Rollup, bool) {
 	win := -1
 	// todo - add statistics to determine why there are conflicts.
 	for i, r := range rollups {
@@ -161,7 +161,7 @@ func FindWinner(parent *Rollup, rollups []*Rollup, db DB, blockResolver common.B
 	return rollups[win], true
 }
 
-func findRoundWinner(receivedRollups []*Rollup, parent *Rollup, parentState State, db DB, blockResolver common.BlockResolver) (*Rollup, State) {
+func findRoundWinner(receivedRollups []*Rollup, parent *Rollup, parentState State, db DB, blockResolver obscurocommon.BlockResolver) (*Rollup, State) {
 	win, found := FindWinner(parent, receivedRollups, db, blockResolver)
 	if !found {
 		panic("This should not happen for gossip rounds.")
@@ -189,13 +189,13 @@ func findRoundWinner(receivedRollups []*Rollup, parent *Rollup, parentState Stat
 
 // mutates the state
 // process deposits from the proof of the parent rollup(exclusive) to the proof of the current rollup
-func processDeposits(fromBlock *types.Block, toBlock *types.Block, s RollupState, blockResolver common.BlockResolver) RollupState {
-	from := common.GenesisBlock.Hash()
-	height := common.L1GenesisHeight
+func processDeposits(fromBlock *types.Block, toBlock *types.Block, s RollupState, blockResolver obscurocommon.BlockResolver) RollupState {
+	from := obscurocommon.GenesisBlock.Hash()
+	height := obscurocommon.L1GenesisHeight
 	if fromBlock != nil {
 		from = fromBlock.Hash()
 		height = blockResolver.HeightBlock(fromBlock)
-		if !common.IsAncestor(fromBlock, toBlock, blockResolver) {
+		if !obscurocommon.IsAncestor(fromBlock, toBlock, blockResolver) {
 			panic("wtf")
 		}
 	}
@@ -206,9 +206,9 @@ func processDeposits(fromBlock *types.Block, toBlock *types.Block, s RollupState
 			break
 		}
 		for _, tx := range b.Transactions() {
-			t := common.TxData(tx)
+			t := obscurocommon.TxData(tx)
 			// transactions to a hardcoded bridge address
-			if t.TxType == common.DepositTx {
+			if t.TxType == obscurocommon.DepositTx {
 				v, f := s.s[t.Dest]
 				if f {
 					s.s[t.Dest] = v + t.Amount
@@ -230,7 +230,7 @@ func processDeposits(fromBlock *types.Block, toBlock *types.Block, s RollupState
 }
 
 // given an L1 block, and the State as it was in the Parent block, calculates the State after the current block.
-func calculateBlockState(b *types.Block, parentState BlockState, db DB, blockResolver common.BlockResolver) BlockState {
+func calculateBlockState(b *types.Block, parentState BlockState, db DB, blockResolver obscurocommon.BlockResolver) BlockState {
 	rollups := extractRollups(b, blockResolver)
 	newHead, found := FindWinner(parentState.Head, rollups, db, blockResolver)
 
@@ -254,17 +254,17 @@ func calculateBlockState(b *types.Block, parentState BlockState, db DB, blockRes
 	return bs
 }
 
-func extractRollups(b *types.Block, blockResolver common.BlockResolver) []*Rollup {
+func extractRollups(b *types.Block, blockResolver obscurocommon.BlockResolver) []*Rollup {
 	rollups := make([]*Rollup, 0)
 	for _, t := range b.Transactions() {
 		// go through all rollup transactions
-		data := common.TxData(t)
-		if data.TxType == common.RollupTx {
-			r := nodecommon.DecodeRollup(common.TxData(t).Rollup)
+		data := obscurocommon.TxData(t)
+		if data.TxType == obscurocommon.RollupTx {
+			r := nodecommon.DecodeRollup(obscurocommon.TxData(t).Rollup)
 
 			// Ignore rollups created with proofs from different L1 blocks
 			// In case of L1 reorgs, rollups may end published on a fork
-			if common.IsBlockAncestor(r.Header.L1Proof, b, blockResolver) {
+			if obscurocommon.IsBlockAncestor(r.Header.L1Proof, b, blockResolver) {
 				rollups = append(rollups, toEnclaveRollup(r))
 			}
 		}

--- a/go/obscuronode/enclave/types.go
+++ b/go/obscuronode/enclave/types.go
@@ -12,8 +12,6 @@ import (
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 )
 
-var GenesisHash = common.HexToHash("1000000000000000000000000000000000000000000000000000000000000000")
-
 // L2TxType indicates the type of L2 transaction - either a transfer or a withdrawal for now
 type L2TxType uint8
 
@@ -75,7 +73,7 @@ func (r *Rollup) Hash() obscurocommon.L2RootHash {
 }
 
 func NewRollup(b *types.Block, parent *Rollup, a common.Address, txs []L2Tx, withdrawals []nodecommon.Withdrawal, nonce obscurocommon.Nonce, state nodecommon.StateRoot) Rollup {
-	parentHash := GenesisHash
+	parentHash := obscurocommon.GenesisHash
 	if parent != nil {
 		parentHash = parent.Hash()
 	}

--- a/go/obscuronode/enclave/types.go
+++ b/go/obscuronode/enclave/types.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/ethereum/go-ethereum/rlp"
 
-	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/obscuronet/obscuro-playground/go/common"
-	nodecommon "github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 )
 
-var GenesisHash = gethcommon.HexToHash("1000000000000000000000000000000000000000000000000000000000000000")
+var GenesisHash = common.HexToHash("1000000000000000000000000000000000000000000000000000000000000000")
 
 // L2TxType indicates the type of L2 transaction - either a transfer or a withdrawal for now
 type L2TxType uint8
@@ -25,8 +25,8 @@ const (
 // L2TxData is the Obscuro transaction data that will be stored encoded in the types.Transaction data field.
 type L2TxData struct {
 	Type   L2TxType
-	From   gethcommon.Address
-	To     gethcommon.Address
+	From   common.Address
+	To     common.Address
 	Amount uint64
 }
 
@@ -45,7 +45,7 @@ func TxData(tx *L2Tx) L2TxData {
 	return data
 }
 
-var GenesisRollup = NewRollup(common.GenesisBlock, nil, gethcommon.HexToAddress("0x0"), []L2Tx{}, []nodecommon.Withdrawal{}, common.GenerateNonce(), "")
+var GenesisRollup = NewRollup(obscurocommon.GenesisBlock, nil, common.HexToAddress("0x0"), []L2Tx{}, []nodecommon.Withdrawal{}, obscurocommon.GenerateNonce(), "")
 
 type Transactions []L2Tx
 
@@ -65,16 +65,16 @@ type Rollup struct {
 
 // Hash returns the keccak256 hash of b's header.
 // The hash is computed on the first call and cached thereafter.
-func (r *Rollup) Hash() common.L2RootHash {
+func (r *Rollup) Hash() obscurocommon.L2RootHash {
 	if hash := r.hash.Load(); hash != nil {
-		return hash.(common.L2RootHash)
+		return hash.(obscurocommon.L2RootHash)
 	}
 	v := r.Header.Hash()
 	r.hash.Store(v)
 	return v
 }
 
-func NewRollup(b *types.Block, parent *Rollup, a gethcommon.Address, txs []L2Tx, withdrawals []nodecommon.Withdrawal, nonce common.Nonce, state nodecommon.StateRoot) Rollup {
+func NewRollup(b *types.Block, parent *Rollup, a common.Address, txs []L2Tx, withdrawals []nodecommon.Withdrawal, nonce obscurocommon.Nonce, state nodecommon.StateRoot) Rollup {
 	parentHash := GenesisHash
 	if parent != nil {
 		parentHash = parent.Hash()
@@ -96,7 +96,7 @@ func NewRollup(b *types.Block, parent *Rollup, a gethcommon.Address, txs []L2Tx,
 
 // ProofHeight - return the height of the L1 proof, or -1 - if the block is not known
 // todo - find a better way. This is a workaround to handle rollups created with proofs that haven't propagated yet
-func (r *Rollup) ProofHeight(l1BlockResolver common.BlockResolver) int {
+func (r *Rollup) ProofHeight(l1BlockResolver obscurocommon.BlockResolver) int {
 	v, f := l1BlockResolver.ResolveBlock(r.Header.L1Proof)
 	if !f {
 		return -1
@@ -111,7 +111,7 @@ func (r *Rollup) ToExtRollup() nodecommon.ExtRollup {
 	}
 }
 
-func (r *Rollup) Proof(l1BlockResolver common.BlockResolver) *types.Block {
+func (r *Rollup) Proof(l1BlockResolver obscurocommon.BlockResolver) *types.Block {
 	v, f := l1BlockResolver.ResolveBlock(r.Header.L1Proof)
 	if !f {
 		panic("Could not find proof for this rollup")

--- a/go/obscuronode/enclave/types_test.go
+++ b/go/obscuronode/enclave/types_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/rlp"
-	common2 "github.com/obscuronet/obscuro-playground/go/obscuronode/common"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 )
 
 func TestSerialiseL2Tx(t *testing.T) {
@@ -28,7 +28,7 @@ func TestSerialiseRollup(t *testing.T) {
 	tx := createL2Tx()
 	height := atomic.Value{}
 	height.Store(1)
-	rollup := common2.Rollup{
+	rollup := nodecommon.Rollup{
 		Header:       GenesisRollup.Header,
 		Height:       height,
 		Transactions: encryptTransactions(Transactions{*tx}),
@@ -37,7 +37,7 @@ func TestSerialiseRollup(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	r1 := common2.Rollup{}
+	r1 := nodecommon.Rollup{}
 
 	err = rlp.Decode(read, &r1)
 	if err != nil {

--- a/go/obscuronode/enclave/utils.go
+++ b/go/obscuronode/enclave/utils.go
@@ -3,9 +3,9 @@ package enclave
 import (
 	"fmt"
 
-	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/obscuronet/obscuro-playground/go/common"
+	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 )
 
 // findTxsNotIncluded - given a list of transactions, it keeps only the ones that were not included in the block
@@ -15,15 +15,15 @@ func findTxsNotIncluded(head *Rollup, txs []L2Tx, db DB) []L2Tx {
 	return removeExisting(txs, included)
 }
 
-func allIncludedTransactions(b *Rollup, db DB) map[gethcommon.Hash]L2Tx {
+func allIncludedTransactions(b *Rollup, db DB) map[common.Hash]L2Tx {
 	val, found := db.Txs(b)
 	if found {
 		return val
 	}
-	if db.HeightRollup(b) == common.L2GenesisHeight {
+	if db.HeightRollup(b) == obscurocommon.L2GenesisHeight {
 		return makeMap(b.Transactions)
 	}
-	newMap := make(map[gethcommon.Hash]L2Tx)
+	newMap := make(map[common.Hash]L2Tx)
 	for k, v := range allIncludedTransactions(db.ParentRollup(b), db) {
 		newMap[k] = v
 	}
@@ -34,7 +34,7 @@ func allIncludedTransactions(b *Rollup, db DB) map[gethcommon.Hash]L2Tx {
 	return newMap
 }
 
-func removeExisting(base []L2Tx, toRemove map[gethcommon.Hash]L2Tx) (r []L2Tx) {
+func removeExisting(base []L2Tx, toRemove map[common.Hash]L2Tx) (r []L2Tx) {
 	for _, t := range base {
 		_, f := toRemove[t.Hash()]
 		if !f {
@@ -45,11 +45,11 @@ func removeExisting(base []L2Tx, toRemove map[gethcommon.Hash]L2Tx) (r []L2Tx) {
 }
 
 // Returns all transactions found 20 levels below
-func historicTxs(r *Rollup, db DB) map[gethcommon.Hash]gethcommon.Hash {
-	i := common.HeightCommittedBlocks
+func historicTxs(r *Rollup, db DB) map[common.Hash]common.Hash {
+	i := obscurocommon.HeightCommittedBlocks
 	c := r
 	for {
-		if i == 0 || db.HeightRollup(c) == common.L2GenesisHeight {
+		if i == 0 || db.HeightRollup(c) == obscurocommon.L2GenesisHeight {
 			return toMap(c.Transactions)
 		}
 		i--
@@ -57,16 +57,16 @@ func historicTxs(r *Rollup, db DB) map[gethcommon.Hash]gethcommon.Hash {
 	}
 }
 
-func makeMap(txs []L2Tx) map[gethcommon.Hash]L2Tx {
-	m := make(map[gethcommon.Hash]L2Tx)
+func makeMap(txs []L2Tx) map[common.Hash]L2Tx {
+	m := make(map[common.Hash]L2Tx)
 	for _, tx := range txs {
 		m[tx.Hash()] = tx
 	}
 	return m
 }
 
-func toMap(txs []L2Tx) map[gethcommon.Hash]gethcommon.Hash {
-	m := make(map[gethcommon.Hash]gethcommon.Hash)
+func toMap(txs []L2Tx) map[common.Hash]common.Hash {
+	m := make(map[common.Hash]common.Hash)
 	for _, tx := range txs {
 		m[tx.Hash()] = tx.Hash()
 	}
@@ -84,9 +84,9 @@ func printTx(t L2Tx, txsString []string) []string {
 	txData := TxData(&t)
 	switch txData.Type {
 	case TransferTx:
-		txsString = append(txsString, fmt.Sprintf("%d->%d(%d){%d}", common.ShortAddress(txData.From), common.ShortAddress(txData.To), txData.Amount, common.ShortHash(t.Hash())))
+		txsString = append(txsString, fmt.Sprintf("%d->%d(%d){%d}", obscurocommon.ShortAddress(txData.From), obscurocommon.ShortAddress(txData.To), txData.Amount, obscurocommon.ShortHash(t.Hash())))
 	case WithdrawalTx:
-		txsString = append(txsString, fmt.Sprintf("%d->*(%d){%d}", common.ShortAddress(txData.From), txData.Amount, common.ShortHash(t.Hash())))
+		txsString = append(txsString, fmt.Sprintf("%d->*(%d){%d}", obscurocommon.ShortAddress(txData.From), txData.Amount, obscurocommon.ShortHash(t.Hash())))
 	}
 	return txsString
 }

--- a/go/obscuronode/enclave/utils.go
+++ b/go/obscuronode/enclave/utils.go
@@ -3,7 +3,7 @@ package enclave
 import (
 	"fmt"
 
-	common2 "github.com/ethereum/go-ethereum/common"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/obscuronet/obscuro-playground/go/common"
 )
@@ -15,7 +15,7 @@ func findTxsNotIncluded(head *Rollup, txs []L2Tx, db DB) []L2Tx {
 	return removeExisting(txs, included)
 }
 
-func allIncludedTransactions(b *Rollup, db DB) map[common2.Hash]L2Tx {
+func allIncludedTransactions(b *Rollup, db DB) map[gethcommon.Hash]L2Tx {
 	val, found := db.Txs(b)
 	if found {
 		return val
@@ -23,7 +23,7 @@ func allIncludedTransactions(b *Rollup, db DB) map[common2.Hash]L2Tx {
 	if db.HeightRollup(b) == common.L2GenesisHeight {
 		return makeMap(b.Transactions)
 	}
-	newMap := make(map[common2.Hash]L2Tx)
+	newMap := make(map[gethcommon.Hash]L2Tx)
 	for k, v := range allIncludedTransactions(db.ParentRollup(b), db) {
 		newMap[k] = v
 	}
@@ -34,7 +34,7 @@ func allIncludedTransactions(b *Rollup, db DB) map[common2.Hash]L2Tx {
 	return newMap
 }
 
-func removeExisting(base []L2Tx, toRemove map[common2.Hash]L2Tx) (r []L2Tx) {
+func removeExisting(base []L2Tx, toRemove map[gethcommon.Hash]L2Tx) (r []L2Tx) {
 	for _, t := range base {
 		_, f := toRemove[t.Hash()]
 		if !f {
@@ -45,7 +45,7 @@ func removeExisting(base []L2Tx, toRemove map[common2.Hash]L2Tx) (r []L2Tx) {
 }
 
 // Returns all transactions found 20 levels below
-func historicTxs(r *Rollup, db DB) map[common2.Hash]common2.Hash {
+func historicTxs(r *Rollup, db DB) map[gethcommon.Hash]gethcommon.Hash {
 	i := common.HeightCommittedBlocks
 	c := r
 	for {
@@ -57,16 +57,16 @@ func historicTxs(r *Rollup, db DB) map[common2.Hash]common2.Hash {
 	}
 }
 
-func makeMap(txs []L2Tx) map[common2.Hash]L2Tx {
-	m := make(map[common2.Hash]L2Tx)
+func makeMap(txs []L2Tx) map[gethcommon.Hash]L2Tx {
+	m := make(map[gethcommon.Hash]L2Tx)
 	for _, tx := range txs {
 		m[tx.Hash()] = tx
 	}
 	return m
 }
 
-func toMap(txs []L2Tx) map[common2.Hash]common2.Hash {
-	m := make(map[common2.Hash]common2.Hash)
+func toMap(txs []L2Tx) map[gethcommon.Hash]gethcommon.Hash {
+	m := make(map[gethcommon.Hash]gethcommon.Hash)
 	for _, tx := range txs {
 		m[tx.Hash()] = tx.Hash()
 	}

--- a/go/obscuronode/header.go
+++ b/go/obscuronode/header.go
@@ -1,8 +1,9 @@
 package obscuronode
 
 import (
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 	"sync"
+
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 
 	"github.com/ethereum/go-ethereum/common"
 )

--- a/go/obscuronode/host/node.go
+++ b/go/obscuronode/host/node.go
@@ -2,10 +2,11 @@ package host
 
 import (
 	"fmt"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode"
 	"sync/atomic"
 	"time"
+
+	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode"
 
 	"github.com/ethereum/go-ethereum/core/types"
 

--- a/go/obscuronode/host/node.go
+++ b/go/obscuronode/host/node.go
@@ -1,4 +1,4 @@
-package obscuronode
+package host
 
 import (
 	"fmt"
@@ -11,7 +11,7 @@ import (
 
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave"
 
-	obscuroCommon "github.com/obscuronet/obscuro-playground/go/obscuronode/common"
+	obscuroCommon "github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 )

--- a/go/obscuronode/nodecommon/encoding.go
+++ b/go/obscuronode/nodecommon/encoding.go
@@ -1,13 +1,9 @@
-package common
+package nodecommon
 
 import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/obscuronet/obscuro-playground/go/common"
 )
-
-func (r Rollup) Encode() (common.EncodedRollup, error) {
-	return rlp.EncodeToBytes(r)
-}
 
 func Decode(encoded common.EncodedRollup) (*Rollup, error) {
 	r := Rollup{}
@@ -17,7 +13,7 @@ func Decode(encoded common.EncodedRollup) (*Rollup, error) {
 }
 
 func EncodeRollup(r *Rollup) common.EncodedRollup {
-	encoded, err := r.Encode()
+	encoded, err := r.encode()
 	if err != nil {
 		panic(err)
 	}
@@ -32,4 +28,8 @@ func DecodeRollup(rollup common.EncodedRollup) *Rollup {
 	}
 
 	return r
+}
+
+func (r Rollup) encode() (common.EncodedRollup, error) {
+	return rlp.EncodeToBytes(r)
 }

--- a/go/obscuronode/nodecommon/encoding.go
+++ b/go/obscuronode/nodecommon/encoding.go
@@ -2,17 +2,17 @@ package nodecommon
 
 import (
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/obscuronet/obscuro-playground/go/common"
+	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 )
 
-func Decode(encoded common.EncodedRollup) (*Rollup, error) {
+func Decode(encoded obscurocommon.EncodedRollup) (*Rollup, error) {
 	r := Rollup{}
 	err := rlp.DecodeBytes(encoded, &r)
 
 	return &r, err
 }
 
-func EncodeRollup(r *Rollup) common.EncodedRollup {
+func EncodeRollup(r *Rollup) obscurocommon.EncodedRollup {
 	encoded, err := r.encode()
 	if err != nil {
 		panic(err)
@@ -21,7 +21,7 @@ func EncodeRollup(r *Rollup) common.EncodedRollup {
 	return encoded
 }
 
-func DecodeRollup(rollup common.EncodedRollup) *Rollup {
+func DecodeRollup(rollup obscurocommon.EncodedRollup) *Rollup {
 	r, err := Decode(rollup)
 	if err != nil {
 		panic(err)
@@ -30,6 +30,6 @@ func DecodeRollup(rollup common.EncodedRollup) *Rollup {
 	return r
 }
 
-func (r Rollup) encode() (common.EncodedRollup, error) {
+func (r Rollup) encode() (obscurocommon.EncodedRollup, error) {
 	return rlp.EncodeToBytes(r)
 }

--- a/go/obscuronode/nodecommon/types.go
+++ b/go/obscuronode/nodecommon/types.go
@@ -2,9 +2,10 @@ package nodecommon
 
 import (
 	"fmt"
+	"sync/atomic"
+
 	"github.com/obscuronet/obscuro-playground/go/hashing"
 	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/common"
 )

--- a/go/obscuronode/nodecommon/types.go
+++ b/go/obscuronode/nodecommon/types.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
-	obscuroCommon "github.com/obscuronet/obscuro-playground/go/common"
+	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -20,10 +20,10 @@ type EncryptedTransactions []EncryptedTx
 
 // Header is in plaintext
 type Header struct {
-	ParentHash  obscuroCommon.L2RootHash
+	ParentHash  obscurocommon.L2RootHash
 	Agg         common.Address
-	Nonce       obscuroCommon.Nonce
-	L1Proof     obscuroCommon.L1RootHash // the L1 block where the Parent was published
+	Nonce       obscurocommon.Nonce
+	L1Proof     obscurocommon.L1RootHash // the L1 block where the Parent was published
 	State       StateRoot
 	Withdrawals []Withdrawal
 }
@@ -58,9 +58,9 @@ func (er ExtRollup) ToRollup() *Rollup {
 
 // Hash returns the keccak256 hash of b's header.
 // The hash is computed on the first call and cached thereafter.
-func (r *Rollup) Hash() obscuroCommon.L2RootHash {
+func (r *Rollup) Hash() obscurocommon.L2RootHash {
 	if hash := r.hash.Load(); hash != nil {
-		return hash.(obscuroCommon.L2RootHash)
+		return hash.(obscurocommon.L2RootHash)
 	}
 	v := r.Header.Hash()
 	r.hash.Store(v)
@@ -70,7 +70,7 @@ func (r *Rollup) Hash() obscuroCommon.L2RootHash {
 
 // Hash returns the block hash of the header, which is simply the keccak256 hash of its
 // RLP encoding.
-func (h *Header) Hash() obscuroCommon.L2RootHash {
+func (h *Header) Hash() obscurocommon.L2RootHash {
 	return rlpHash(h)
 }
 

--- a/integration/ethereummock/db.go
+++ b/integration/ethereummock/db.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 
-	common2 "github.com/obscuronet/obscuro-playground/go/common"
+	"github.com/obscuronet/obscuro-playground/go/common"
 )
 
 type blockAndHeight struct {
@@ -15,13 +15,13 @@ type blockAndHeight struct {
 
 // Received blocks ar stored here
 type blockResolverInMem struct {
-	blockCache map[common2.L1RootHash]blockAndHeight
+	blockCache map[common.L1RootHash]blockAndHeight
 	m          sync.RWMutex
 }
 
-func NewResolver() common2.BlockResolver {
+func NewResolver() common.BlockResolver {
 	return &blockResolverInMem{
-		blockCache: map[common2.L1RootHash]blockAndHeight{},
+		blockCache: map[common.L1RootHash]blockAndHeight{},
 		m:          sync.RWMutex{},
 	}
 }
@@ -29,7 +29,7 @@ func NewResolver() common2.BlockResolver {
 func (n *blockResolverInMem) StoreBlock(block *types.Block) {
 	n.m.Lock()
 	defer n.m.Unlock()
-	if block.ParentHash() == common2.GenesisHash {
+	if block.ParentHash() == common.GenesisHash {
 		n.blockCache[block.Hash()] = blockAndHeight{block, 0}
 		return
 	}
@@ -41,7 +41,7 @@ func (n *blockResolverInMem) StoreBlock(block *types.Block) {
 	n.blockCache[block.Hash()] = blockAndHeight{block, p.height + 1}
 }
 
-func (n *blockResolverInMem) ResolveBlock(hash common2.L1RootHash) (*types.Block, bool) {
+func (n *blockResolverInMem) ResolveBlock(hash common.L1RootHash) (*types.Block, bool) {
 	n.m.RLock()
 	defer n.m.RUnlock()
 	block, f := n.blockCache[hash]
@@ -56,23 +56,23 @@ func (n *blockResolverInMem) HeightBlock(block *types.Block) int {
 }
 
 func (n *blockResolverInMem) ParentBlock(block *types.Block) (*types.Block, bool) {
-	return common2.Parent(n, block)
+	return common.Parent(n, block)
 }
 
 // The cache of included transactions
 type txDBInMem struct {
-	transactionsPerBlockCache map[common2.L1RootHash]map[common2.TxHash]*common2.L1Tx
+	transactionsPerBlockCache map[common.L1RootHash]map[common.TxHash]*common.L1Tx
 	rpbcM                     *sync.RWMutex
 }
 
 func NewTxDB() TxDB {
 	return &txDBInMem{
-		transactionsPerBlockCache: make(map[common2.L1RootHash]map[common2.TxHash]*common2.L1Tx),
+		transactionsPerBlockCache: make(map[common.L1RootHash]map[common.TxHash]*common.L1Tx),
 		rpbcM:                     &sync.RWMutex{},
 	}
 }
 
-func (n *txDBInMem) Txs(b *types.Block) (map[common2.TxHash]*common2.L1Tx, bool) {
+func (n *txDBInMem) Txs(b *types.Block) (map[common.TxHash]*common.L1Tx, bool) {
 	n.rpbcM.RLock()
 	val, found := n.transactionsPerBlockCache[b.Hash()]
 	n.rpbcM.RUnlock()
@@ -80,7 +80,7 @@ func (n *txDBInMem) Txs(b *types.Block) (map[common2.TxHash]*common2.L1Tx, bool)
 	return val, found
 }
 
-func (n *txDBInMem) AddTxs(b *types.Block, newMap map[common2.TxHash]*common2.L1Tx) {
+func (n *txDBInMem) AddTxs(b *types.Block, newMap map[common.TxHash]*common.L1Tx) {
 	n.rpbcM.Lock()
 	n.transactionsPerBlockCache[b.Hash()] = newMap
 	n.rpbcM.Unlock()
@@ -90,11 +90,11 @@ func (n *txDBInMem) AddTxs(b *types.Block, newMap map[common2.TxHash]*common2.L1
 // deep have been removed.
 func removeCommittedTransactions(
 	cb *types.Block,
-	mempool []*common2.L1Tx,
-	resolver common2.BlockResolver,
+	mempool []*common.L1Tx,
+	resolver common.BlockResolver,
 	db TxDB,
-) []*common2.L1Tx {
-	if resolver.HeightBlock(cb) <= common2.HeightCommittedBlocks {
+) []*common.L1Tx {
+	if resolver.HeightBlock(cb) <= common.HeightCommittedBlocks {
 		return mempool
 	}
 
@@ -102,7 +102,7 @@ func removeCommittedTransactions(
 	i := 0
 
 	for {
-		if i == common2.HeightCommittedBlocks {
+		if i == common.HeightCommittedBlocks {
 			break
 		}
 

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -2,9 +2,10 @@ package ethereummock
 
 import (
 	"fmt"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 	"sync/atomic"
 	"time"
+
+	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 
 	"github.com/obscuronet/obscuro-playground/go/log"
 

--- a/integration/ethereummock/utils.go
+++ b/integration/ethereummock/utils.go
@@ -2,12 +2,12 @@ package ethereummock
 
 import (
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/go/common"
+	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 )
 
 // LCA - returns the least nodecommon ancestor of the 2 blocks
-func LCA(blockA *types.Block, blockB *types.Block, resolver common.BlockResolver) *types.Block {
-	if resolver.HeightBlock(blockA) == common.L1GenesisHeight || resolver.HeightBlock(blockB) == common.L1GenesisHeight {
+func LCA(blockA *types.Block, blockB *types.Block, resolver obscurocommon.BlockResolver) *types.Block {
+	if resolver.HeightBlock(blockA) == obscurocommon.L1GenesisHeight || resolver.HeightBlock(blockB) == obscurocommon.L1GenesisHeight {
 		return blockA
 	}
 	if blockA.Hash() == blockB.Hash() {
@@ -42,20 +42,20 @@ func LCA(blockA *types.Block, blockB *types.Block, resolver common.BlockResolver
 
 // findNotIncludedTxs - given a list of transactions, it keeps only the ones that were not included in the block
 // todo - inefficient
-func findNotIncludedTxs(head *types.Block, txs []*common.L1Tx, r common.BlockResolver, db TxDB) []*common.L1Tx {
+func findNotIncludedTxs(head *types.Block, txs []*obscurocommon.L1Tx, r obscurocommon.BlockResolver, db TxDB) []*obscurocommon.L1Tx {
 	included := allIncludedTransactions(head, r, db)
 	return removeExisting(txs, included)
 }
 
-func allIncludedTransactions(b *types.Block, r common.BlockResolver, db TxDB) map[common.TxHash]*common.L1Tx {
+func allIncludedTransactions(b *types.Block, r obscurocommon.BlockResolver, db TxDB) map[obscurocommon.TxHash]*obscurocommon.L1Tx {
 	val, found := db.Txs(b)
 	if found {
 		return val
 	}
-	if r.HeightBlock(b) == common.L1GenesisHeight {
+	if r.HeightBlock(b) == obscurocommon.L1GenesisHeight {
 		return makeMap(b.Transactions())
 	}
-	newMap := make(map[common.TxHash]*common.L1Tx)
+	newMap := make(map[obscurocommon.TxHash]*obscurocommon.L1Tx)
 	p, f := r.ParentBlock(b)
 	if !f {
 		panic("wtf")
@@ -70,7 +70,7 @@ func allIncludedTransactions(b *types.Block, r common.BlockResolver, db TxDB) ma
 	return newMap
 }
 
-func removeExisting(base []*common.L1Tx, toRemove map[common.TxHash]*common.L1Tx) (r []*common.L1Tx) {
+func removeExisting(base []*obscurocommon.L1Tx, toRemove map[obscurocommon.TxHash]*obscurocommon.L1Tx) (r []*obscurocommon.L1Tx) {
 	for _, t := range base {
 		_, f := toRemove[t.Hash()]
 		if !f {
@@ -80,15 +80,15 @@ func removeExisting(base []*common.L1Tx, toRemove map[common.TxHash]*common.L1Tx
 	return
 }
 
-func makeMap(txs types.Transactions) map[common.TxHash]*common.L1Tx {
-	m := make(map[common.TxHash]*common.L1Tx)
+func makeMap(txs types.Transactions) map[obscurocommon.TxHash]*obscurocommon.L1Tx {
+	m := make(map[obscurocommon.TxHash]*obscurocommon.L1Tx)
 	for _, tx := range txs {
 		m[tx.Hash()] = tx
 	}
 	return m
 }
 
-func BlocksBetween(blockA *types.Block, blockB *types.Block, resolver common.BlockResolver) []*types.Block {
+func BlocksBetween(blockA *types.Block, blockB *types.Block, resolver obscurocommon.BlockResolver) []*types.Block {
 	if blockA.Hash() == blockB.Hash() {
 		return []*types.Block{blockA}
 	}

--- a/integration/ethereummock/utils.go
+++ b/integration/ethereummock/utils.go
@@ -2,12 +2,12 @@ package ethereummock
 
 import (
 	"github.com/ethereum/go-ethereum/core/types"
-	common2 "github.com/obscuronet/obscuro-playground/go/common"
+	"github.com/obscuronet/obscuro-playground/go/common"
 )
 
-// LCA - returns the least common ancestor of the 2 blocks
-func LCA(blockA *types.Block, blockB *types.Block, resolver common2.BlockResolver) *types.Block {
-	if resolver.HeightBlock(blockA) == common2.L1GenesisHeight || resolver.HeightBlock(blockB) == common2.L1GenesisHeight {
+// LCA - returns the least nodecommon ancestor of the 2 blocks
+func LCA(blockA *types.Block, blockB *types.Block, resolver common.BlockResolver) *types.Block {
+	if resolver.HeightBlock(blockA) == common.L1GenesisHeight || resolver.HeightBlock(blockB) == common.L1GenesisHeight {
 		return blockA
 	}
 	if blockA.Hash() == blockB.Hash() {
@@ -42,20 +42,20 @@ func LCA(blockA *types.Block, blockB *types.Block, resolver common2.BlockResolve
 
 // findNotIncludedTxs - given a list of transactions, it keeps only the ones that were not included in the block
 // todo - inefficient
-func findNotIncludedTxs(head *types.Block, txs []*common2.L1Tx, r common2.BlockResolver, db TxDB) []*common2.L1Tx {
+func findNotIncludedTxs(head *types.Block, txs []*common.L1Tx, r common.BlockResolver, db TxDB) []*common.L1Tx {
 	included := allIncludedTransactions(head, r, db)
 	return removeExisting(txs, included)
 }
 
-func allIncludedTransactions(b *types.Block, r common2.BlockResolver, db TxDB) map[common2.TxHash]*common2.L1Tx {
+func allIncludedTransactions(b *types.Block, r common.BlockResolver, db TxDB) map[common.TxHash]*common.L1Tx {
 	val, found := db.Txs(b)
 	if found {
 		return val
 	}
-	if r.HeightBlock(b) == common2.L1GenesisHeight {
+	if r.HeightBlock(b) == common.L1GenesisHeight {
 		return makeMap(b.Transactions())
 	}
-	newMap := make(map[common2.TxHash]*common2.L1Tx)
+	newMap := make(map[common.TxHash]*common.L1Tx)
 	p, f := r.ParentBlock(b)
 	if !f {
 		panic("wtf")
@@ -70,7 +70,7 @@ func allIncludedTransactions(b *types.Block, r common2.BlockResolver, db TxDB) m
 	return newMap
 }
 
-func removeExisting(base []*common2.L1Tx, toRemove map[common2.TxHash]*common2.L1Tx) (r []*common2.L1Tx) {
+func removeExisting(base []*common.L1Tx, toRemove map[common.TxHash]*common.L1Tx) (r []*common.L1Tx) {
 	for _, t := range base {
 		_, f := toRemove[t.Hash()]
 		if !f {
@@ -80,15 +80,15 @@ func removeExisting(base []*common2.L1Tx, toRemove map[common2.TxHash]*common2.L
 	return
 }
 
-func makeMap(txs types.Transactions) map[common2.TxHash]*common2.L1Tx {
-	m := make(map[common2.TxHash]*common2.L1Tx)
+func makeMap(txs types.Transactions) map[common.TxHash]*common.L1Tx {
+	m := make(map[common.TxHash]*common.L1Tx)
 	for _, tx := range txs {
 		m[tx.Hash()] = tx
 	}
 	return m
 }
 
-func BlocksBetween(blockA *types.Block, blockB *types.Block, resolver common2.BlockResolver) []*types.Block {
+func BlocksBetween(blockA *types.Block, blockB *types.Block, resolver common.BlockResolver) []*types.Block {
 	if blockA.Hash() == blockB.Hash() {
 		return []*types.Block{blockA}
 	}

--- a/integration/ethereummock/utils.go
+++ b/integration/ethereummock/utils.go
@@ -5,7 +5,7 @@ import (
 	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 )
 
-// LCA - returns the least nodecommon ancestor of the 2 blocks
+// LCA - returns the least common ancestor of the 2 blocks
 func LCA(blockA *types.Block, blockB *types.Block, resolver obscurocommon.BlockResolver) *types.Block {
 	if resolver.HeightBlock(blockA) == obscurocommon.L1GenesisHeight || resolver.HeightBlock(blockB) == obscurocommon.L1GenesisHeight {
 		return blockA

--- a/integration/simulation/cmd/main.go
+++ b/integration/simulation/cmd/main.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/obscuronet/obscuro-playground/go/common"
+	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 	"github.com/obscuronet/obscuro-playground/integration/simulation"
 )
 
@@ -37,7 +37,7 @@ func main() {
 		panic(err)
 	}
 	defer f1.Close()
-	common.SetLog(f1)
+	obscurocommon.SetLog(f1)
 
 	blockDuration := uint64(25_000)
 	l1netw, _ := simulation.RunSimulation(

--- a/integration/simulation/l1_network.go
+++ b/integration/simulation/l1_network.go
@@ -4,14 +4,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	common2 "github.com/obscuronet/obscuro-playground/go/common"
+	"github.com/obscuronet/obscuro-playground/go/common"
 	ethereum_mock "github.com/obscuronet/obscuro-playground/integration/ethereummock"
 )
 
 // L1NetworkCfg - models a full network including artificial random latencies
 type L1NetworkCfg struct {
 	nodes []*ethereum_mock.Node
-	delay common2.Latency // the latency
+	delay common.Latency // the latency
 	Stats *Stats
 	// used as a signal to stop all network communication.
 	// This helps prevent deadlocks when stopping nodes
@@ -19,7 +19,7 @@ type L1NetworkCfg struct {
 }
 
 // BroadcastBlock broadcast a block to the l1 nodes
-func (n *L1NetworkCfg) BroadcastBlock(b common2.EncodedBlock, p common2.EncodedBlock) {
+func (n *L1NetworkCfg) BroadcastBlock(b common.EncodedBlock, p common.EncodedBlock) {
 	if atomic.LoadInt32(n.interrupt) == 1 {
 		return
 	}
@@ -28,9 +28,9 @@ func (n *L1NetworkCfg) BroadcastBlock(b common2.EncodedBlock, p common2.EncodedB
 	for _, m := range n.nodes {
 		if m.ID != bl.Header().Coinbase {
 			t := m
-			common2.Schedule(n.delay(), func() { t.P2PReceiveBlock(b, p) })
+			common.Schedule(n.delay(), func() { t.P2PReceiveBlock(b, p) })
 		} else {
-			common2.Log(printBlock(bl, *m))
+			common.Log(printBlock(bl, *m))
 		}
 	}
 
@@ -38,7 +38,7 @@ func (n *L1NetworkCfg) BroadcastBlock(b common2.EncodedBlock, p common2.EncodedB
 }
 
 // BroadcastTx Broadcasts the L1 tx containing the rollup to the L1 network
-func (n *L1NetworkCfg) BroadcastTx(tx common2.EncodedL1Tx) {
+func (n *L1NetworkCfg) BroadcastTx(tx common.EncodedL1Tx) {
 	if atomic.LoadInt32(n.interrupt) == 1 {
 		return
 	}
@@ -47,8 +47,8 @@ func (n *L1NetworkCfg) BroadcastTx(tx common2.EncodedL1Tx) {
 		t := m
 		// the time to broadcast a tx is half that of a L1 block, because it is smaller.
 		// todo - find a better way to express this
-		d := common2.Max(n.delay()/2, 1)
-		common2.Schedule(d, func() { t.P2PGossipTx(tx) })
+		d := common.Max(n.delay()/2, 1)
+		common.Schedule(d, func() { t.P2PGossipTx(tx) })
 	}
 }
 

--- a/integration/simulation/l1_network.go
+++ b/integration/simulation/l1_network.go
@@ -4,14 +4,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/obscuronet/obscuro-playground/go/common"
+	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 	ethereum_mock "github.com/obscuronet/obscuro-playground/integration/ethereummock"
 )
 
 // L1NetworkCfg - models a full network including artificial random latencies
 type L1NetworkCfg struct {
 	nodes []*ethereum_mock.Node
-	delay common.Latency // the latency
+	delay obscurocommon.Latency // the latency
 	Stats *Stats
 	// used as a signal to stop all network communication.
 	// This helps prevent deadlocks when stopping nodes
@@ -19,7 +19,7 @@ type L1NetworkCfg struct {
 }
 
 // BroadcastBlock broadcast a block to the l1 nodes
-func (n *L1NetworkCfg) BroadcastBlock(b common.EncodedBlock, p common.EncodedBlock) {
+func (n *L1NetworkCfg) BroadcastBlock(b obscurocommon.EncodedBlock, p obscurocommon.EncodedBlock) {
 	if atomic.LoadInt32(n.interrupt) == 1 {
 		return
 	}
@@ -28,9 +28,9 @@ func (n *L1NetworkCfg) BroadcastBlock(b common.EncodedBlock, p common.EncodedBlo
 	for _, m := range n.nodes {
 		if m.ID != bl.Header().Coinbase {
 			t := m
-			common.Schedule(n.delay(), func() { t.P2PReceiveBlock(b, p) })
+			obscurocommon.Schedule(n.delay(), func() { t.P2PReceiveBlock(b, p) })
 		} else {
-			common.Log(printBlock(bl, *m))
+			obscurocommon.Log(printBlock(bl, *m))
 		}
 	}
 
@@ -38,7 +38,7 @@ func (n *L1NetworkCfg) BroadcastBlock(b common.EncodedBlock, p common.EncodedBlo
 }
 
 // BroadcastTx Broadcasts the L1 tx containing the rollup to the L1 network
-func (n *L1NetworkCfg) BroadcastTx(tx common.EncodedL1Tx) {
+func (n *L1NetworkCfg) BroadcastTx(tx obscurocommon.EncodedL1Tx) {
 	if atomic.LoadInt32(n.interrupt) == 1 {
 		return
 	}
@@ -47,8 +47,8 @@ func (n *L1NetworkCfg) BroadcastTx(tx common.EncodedL1Tx) {
 		t := m
 		// the time to broadcast a tx is half that of a L1 block, because it is smaller.
 		// todo - find a better way to express this
-		d := common.Max(n.delay()/2, 1)
-		common.Schedule(d, func() { t.P2PGossipTx(tx) })
+		d := obscurocommon.Max(n.delay()/2, 1)
+		obscurocommon.Schedule(d, func() { t.P2PGossipTx(tx) })
 	}
 }
 

--- a/integration/simulation/l1_network.go
+++ b/integration/simulation/l1_network.go
@@ -1,9 +1,10 @@
 package simulation
 
 import (
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 	"sync/atomic"
 	"time"
+
+	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 
 	"github.com/obscuronet/obscuro-playground/go/log"
 

--- a/integration/simulation/l2_network.go
+++ b/integration/simulation/l2_network.go
@@ -1,8 +1,9 @@
 package simulation
 
 import (
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
 	"time"
+
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
 
 	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"

--- a/integration/simulation/l2_network.go
+++ b/integration/simulation/l2_network.go
@@ -3,32 +3,33 @@ package simulation
 import (
 	"time"
 
-	common3 "github.com/obscuronet/obscuro-playground/go/common"
-	obscuro_node "github.com/obscuronet/obscuro-playground/go/obscuronode"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/common"
+	obscuro_node "github.com/obscuronet/obscuro-playground/go/obscuronode/host"
+
+	"github.com/obscuronet/obscuro-playground/go/common"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 )
 
 // L2NetworkCfg - models a full network including artificial random latencies
 type L2NetworkCfg struct {
 	nodes []*obscuro_node.Node
-	delay common3.Latency // the latency
+	delay common.Latency // the latency
 }
 
 // BroadcastRollup Broadcasts the rollup to all L2 peers
-func (cfg *L2NetworkCfg) BroadcastRollup(r common3.EncodedRollup) {
+func (cfg *L2NetworkCfg) BroadcastRollup(r common.EncodedRollup) {
 	for _, a := range cfg.nodes {
-		rol := common.DecodeRollup(r)
+		rol := nodecommon.DecodeRollup(r)
 		if a.ID != rol.Header.Agg {
 			t := a
-			common3.Schedule(cfg.delay(), func() { t.P2PGossipRollup(r) })
+			common.Schedule(cfg.delay(), func() { t.P2PGossipRollup(r) })
 		}
 	}
 }
 
-func (cfg *L2NetworkCfg) BroadcastTx(tx common.EncryptedTx) {
+func (cfg *L2NetworkCfg) BroadcastTx(tx nodecommon.EncryptedTx) {
 	for _, a := range cfg.nodes {
 		t := a
-		common3.Schedule(cfg.delay()/2, func() { t.P2PReceiveTx(tx) })
+		common.Schedule(cfg.delay()/2, func() { t.P2PReceiveTx(tx) })
 	}
 }
 

--- a/integration/simulation/l2_network.go
+++ b/integration/simulation/l2_network.go
@@ -3,25 +3,25 @@ package simulation
 import (
 	"time"
 
-	obscuro_node "github.com/obscuronet/obscuro-playground/go/obscuronode/host"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
 
-	"github.com/obscuronet/obscuro-playground/go/common"
+	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 )
 
 // L2NetworkCfg - models a full network including artificial random latencies
 type L2NetworkCfg struct {
-	nodes []*obscuro_node.Node
-	delay common.Latency // the latency
+	nodes []*host.Node
+	delay obscurocommon.Latency // the latency
 }
 
 // BroadcastRollup Broadcasts the rollup to all L2 peers
-func (cfg *L2NetworkCfg) BroadcastRollup(r common.EncodedRollup) {
+func (cfg *L2NetworkCfg) BroadcastRollup(r obscurocommon.EncodedRollup) {
 	for _, a := range cfg.nodes {
 		rol := nodecommon.DecodeRollup(r)
 		if a.ID != rol.Header.Agg {
 			t := a
-			common.Schedule(cfg.delay(), func() { t.P2PGossipRollup(r) })
+			obscurocommon.Schedule(cfg.delay(), func() { t.P2PGossipRollup(r) })
 		}
 	}
 }
@@ -29,7 +29,7 @@ func (cfg *L2NetworkCfg) BroadcastRollup(r common.EncodedRollup) {
 func (cfg *L2NetworkCfg) BroadcastTx(tx nodecommon.EncryptedTx) {
 	for _, a := range cfg.nodes {
 		t := a
-		common.Schedule(cfg.delay()/2, func() { t.P2PReceiveTx(tx) })
+		obscurocommon.Schedule(cfg.delay()/2, func() { t.P2PReceiveTx(tx) })
 	}
 }
 

--- a/integration/simulation/output_stats.go
+++ b/integration/simulation/output_stats.go
@@ -2,6 +2,7 @@ package simulation
 
 import (
 	"fmt"
+
 	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 )

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -6,11 +6,12 @@ import (
 	"math/rand"
 	"time"
 
-	common2 "github.com/ethereum/go-ethereum/common"
+	obscuro_node "github.com/obscuronet/obscuro-playground/go/obscuronode/host"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave"
 
 	"github.com/obscuronet/obscuro-playground/go/common"
-	obscuro_node "github.com/obscuronet/obscuro-playground/go/obscuronode"
 	ethereum_mock "github.com/obscuronet/obscuro-playground/integration/ethereummock"
 	wallet_mock "github.com/obscuronet/obscuro-playground/integration/walletmock"
 )
@@ -53,11 +54,11 @@ func RunSimulation(
 			genesis = true
 		}
 		// create a layer 2 node
-		agg := obscuro_node.NewAgg(common2.BigToAddress(big.NewInt(int64(i))), l2Cfg, nil, &l2Network, &stats, genesis)
+		agg := obscuro_node.NewAgg(gethcommon.BigToAddress(big.NewInt(int64(i))), l2Cfg, nil, &l2Network, &stats, genesis)
 		l2Network.nodes = append(l2Network.nodes, &agg)
 
 		// create a layer 1 node responsible with notifying the layer 2 node about blocks
-		miner := ethereum_mock.NewMiner(common2.BigToAddress(big.NewInt(int64(i))), l1Cfg, &agg, &l1Network, &stats)
+		miner := ethereum_mock.NewMiner(gethcommon.BigToAddress(big.NewInt(int64(i))), l1Cfg, &agg, &l1Network, &stats)
 		l1Network.nodes = append(l1Network.nodes, &miner)
 		agg.L1Node = &miner
 	}

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -2,11 +2,12 @@ package simulation
 
 import (
 	"fmt"
+	"math/big"
+	"time"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
-	"math/big"
-	"time"
 
 	"github.com/obscuronet/obscuro-playground/go/log"
 

--- a/integration/simulation/simulation_test.go
+++ b/integration/simulation/simulation_test.go
@@ -2,13 +2,14 @@ package simulation
 
 import (
 	"fmt"
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 	"math/rand"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 
 	"github.com/ethereum/go-ethereum/common"
 

--- a/integration/simulation/simulation_test.go
+++ b/integration/simulation/simulation_test.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 
-	common2 "github.com/ethereum/go-ethereum/common"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/google/uuid"
 	"github.com/obscuronet/obscuro-playground/go/common"
-	obscuroCommon "github.com/obscuronet/obscuro-playground/go/obscuronode/common"
 	enclave2 "github.com/obscuronet/obscuro-playground/go/obscuronode/enclave"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 	ethereum_mock "github.com/obscuronet/obscuro-playground/integration/ethereummock"
 )
 
@@ -59,7 +59,7 @@ const L2EfficiencyThreashold = 0.3
 
 // Sanity check
 func validateL1(t *testing.T, b *types.Block, s *Stats, db enclave2.DB, resolver common.BlockResolver) {
-	deposits := make([]common2.Hash, 0)
+	deposits := make([]gethcommon.Hash, 0)
 	rollups := make([]common.L2RootHash, 0)
 	s.l1Height = db.HeightBlock(b)
 	totalDeposited := uint64(0)
@@ -75,7 +75,7 @@ func validateL1(t *testing.T, b *types.Block, s *Stats, db enclave2.DB, resolver
 				deposits = append(deposits, tr.Hash())
 				totalDeposited += tx.Amount
 			case common.RollupTx:
-				r := obscuroCommon.DecodeRollup(tx.Rollup)
+				r := nodecommon.DecodeRollup(tx.Rollup)
 				rollups = append(rollups, r.Hash())
 				if common.IsBlockAncestor(r.Header.L1Proof, b, resolver) {
 					// only count the rollup if it is published in the right branch
@@ -121,9 +121,9 @@ func validateL1(t *testing.T, b *types.Block, s *Stats, db enclave2.DB, resolver
 
 func validateL2(t *testing.T, r *enclave2.Rollup, s *Stats, db enclave2.DB) uint64 {
 	s.l2Height = db.HeightRollup(r)
-	transfers := make([]common2.Hash, 0)
+	transfers := make([]gethcommon.Hash, 0)
 	withdrawalTxs := make([]enclave2.L2Tx, 0)
-	withdrawalRequests := make([]obscuroCommon.Withdrawal, 0)
+	withdrawalRequests := make([]nodecommon.Withdrawal, 0)
 	for {
 		if db.HeightRollup(r) == common.L2GenesisHeight {
 			break
@@ -166,7 +166,7 @@ func validateL2(t *testing.T, r *enclave2.Rollup, s *Stats, db enclave2.DB) uint
 	return sumWithdrawals(withdrawalRequests)
 }
 
-func sumWithdrawals(w []obscuroCommon.Withdrawal) uint64 {
+func sumWithdrawals(w []nodecommon.Withdrawal) uint64 {
 	sum := uint64(0)
 	for _, r := range w {
 		sum += r.Amount

--- a/integration/simulation/stats.go
+++ b/integration/simulation/stats.go
@@ -3,11 +3,11 @@ package simulation
 import (
 	"sync"
 
-	"github.com/ethereum/go-ethereum/common"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
-	common3 "github.com/obscuronet/obscuro-playground/go/common"
-	common2 "github.com/obscuronet/obscuro-playground/go/obscuronode/common"
+	"github.com/obscuronet/obscuro-playground/go/common"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 )
 
 // Stats - collects information during the simulation. It can be checked programmatically.
@@ -23,13 +23,13 @@ type Stats struct {
 
 	l2Height           int
 	totalL2Blocks      int
-	l2Head             *common2.Rollup
+	l2Head             *nodecommon.Rollup
 	maxRollupsPerBlock uint32
 	nrEmptyBlocks      int
 
 	totalL2Txs  int
-	noL1Reorgs  map[common.Address]int
-	noL2Recalcs map[common.Address]int
+	noL1Reorgs  map[gethcommon.Address]int
+	noL2Recalcs map[gethcommon.Address]int
 	// todo - actual avg block Duration
 
 	totalDepositedAmount      uint64
@@ -46,19 +46,19 @@ func NewStats(nrMiners int, simulationTime int, avgBlockDuration uint64, avgLate
 		avgBlockDuration: avgBlockDuration,
 		avgLatency:       avgLatency,
 		gossipPeriod:     gossipPeriod,
-		noL1Reorgs:       map[common.Address]int{},
-		noL2Recalcs:      map[common.Address]int{},
+		noL1Reorgs:       map[gethcommon.Address]int{},
+		noL2Recalcs:      map[gethcommon.Address]int{},
 		statsMu:          &sync.RWMutex{},
 	}
 }
 
-func (s *Stats) L1Reorg(id common.Address) {
+func (s *Stats) L1Reorg(id gethcommon.Address) {
 	s.statsMu.Lock()
 	s.noL1Reorgs[id]++
 	s.statsMu.Unlock()
 }
 
-func (s *Stats) L2Recalc(id common.Address) {
+func (s *Stats) L2Recalc(id gethcommon.Address) {
 	s.statsMu.Lock()
 	s.noL2Recalcs[id]++
 	s.statsMu.Unlock()
@@ -66,16 +66,16 @@ func (s *Stats) L2Recalc(id common.Address) {
 
 func (s *Stats) NewBlock(b *types.Block) {
 	s.statsMu.Lock()
-	// s.l1Height = common.MaxInt(s.l1Height, b.Height)
+	// s.l1Height = nodecommon.MaxInt(s.l1Height, b.Height)
 	s.totalL1Blocks++
-	s.maxRollupsPerBlock = common3.MaxInt(s.maxRollupsPerBlock, uint32(len(b.Transactions())))
+	s.maxRollupsPerBlock = common.MaxInt(s.maxRollupsPerBlock, uint32(len(b.Transactions())))
 	if len(b.Transactions()) == 0 {
 		s.nrEmptyBlocks++
 	}
 	s.statsMu.Unlock()
 }
 
-func (s *Stats) NewRollup(r *common2.Rollup) {
+func (s *Stats) NewRollup(r *nodecommon.Rollup) {
 	s.statsMu.Lock()
 	s.l2Head = r
 	s.totalL2Blocks++

--- a/integration/simulation/stats.go
+++ b/integration/simulation/stats.go
@@ -3,10 +3,10 @@ package simulation
 import (
 	"sync"
 
-	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/obscuronet/obscuro-playground/go/common"
+	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 )
 
@@ -28,8 +28,8 @@ type Stats struct {
 	nrEmptyBlocks      int
 
 	totalL2Txs  int
-	noL1Reorgs  map[gethcommon.Address]int
-	noL2Recalcs map[gethcommon.Address]int
+	noL1Reorgs  map[common.Address]int
+	noL2Recalcs map[common.Address]int
 	// todo - actual avg block Duration
 
 	totalDepositedAmount      uint64
@@ -46,19 +46,19 @@ func NewStats(nrMiners int, simulationTime int, avgBlockDuration uint64, avgLate
 		avgBlockDuration: avgBlockDuration,
 		avgLatency:       avgLatency,
 		gossipPeriod:     gossipPeriod,
-		noL1Reorgs:       map[gethcommon.Address]int{},
-		noL2Recalcs:      map[gethcommon.Address]int{},
+		noL1Reorgs:       map[common.Address]int{},
+		noL2Recalcs:      map[common.Address]int{},
 		statsMu:          &sync.RWMutex{},
 	}
 }
 
-func (s *Stats) L1Reorg(id gethcommon.Address) {
+func (s *Stats) L1Reorg(id common.Address) {
 	s.statsMu.Lock()
 	s.noL1Reorgs[id]++
 	s.statsMu.Unlock()
 }
 
-func (s *Stats) L2Recalc(id gethcommon.Address) {
+func (s *Stats) L2Recalc(id common.Address) {
 	s.statsMu.Lock()
 	s.noL2Recalcs[id]++
 	s.statsMu.Unlock()
@@ -68,7 +68,7 @@ func (s *Stats) NewBlock(b *types.Block) {
 	s.statsMu.Lock()
 	// s.l1Height = nodecommon.MaxInt(s.l1Height, b.Height)
 	s.totalL1Blocks++
-	s.maxRollupsPerBlock = common.MaxInt(s.maxRollupsPerBlock, uint32(len(b.Transactions())))
+	s.maxRollupsPerBlock = obscurocommon.MaxInt(s.maxRollupsPerBlock, uint32(len(b.Transactions())))
 	if len(b.Transactions()) == 0 {
 		s.nrEmptyBlocks++
 	}

--- a/integration/simulation/transaction_manager.go
+++ b/integration/simulation/transaction_manager.go
@@ -1,11 +1,12 @@
 package simulation
 
 import (
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 	"math/rand"
 	"sync"
 	"time"
+
+	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave"
 	"golang.org/x/sync/errgroup"

--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/obscuronet/obscuro-playground/go/common"
+	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 	ethereum_mock "github.com/obscuronet/obscuro-playground/integration/ethereummock"
 )
 
@@ -15,12 +15,12 @@ func printBlock(b *types.Block, m ethereum_mock.Node) string {
 	// This is just for printing
 	var txs []string
 	for _, tx := range b.Transactions() {
-		t := common.TxData(tx)
-		if t.TxType == common.RollupTx {
+		t := obscurocommon.TxData(tx)
+		if t.TxType == obscurocommon.RollupTx {
 			r := nodecommon.DecodeRollup(t.Rollup)
-			txs = append(txs, fmt.Sprintf("r_%d", common.ShortHash(r.Hash())))
-		} else if t.TxType == common.DepositTx {
-			txs = append(txs, fmt.Sprintf("deposit(%d=%d)", common.ShortAddress(t.Dest), t.Amount))
+			txs = append(txs, fmt.Sprintf("r_%d", obscurocommon.ShortHash(r.Hash())))
+		} else if t.TxType == obscurocommon.DepositTx {
+			txs = append(txs, fmt.Sprintf("deposit(%d=%d)", obscurocommon.ShortAddress(t.Dest), t.Amount))
 		}
 	}
 	p, f := m.Resolver.ParentBlock(b)
@@ -29,5 +29,5 @@ func printBlock(b *types.Block, m ethereum_mock.Node) string {
 	}
 
 	return fmt.Sprintf("> M%d: create b_%d(Height=%d, Nonce=%d)[parent=b_%d]. Txs: %v",
-		common.ShortAddress(m.ID), common.ShortHash(b.Hash()), m.Resolver.HeightBlock(b), common.ShortNonce(b.Header().Nonce), common.ShortHash(p.Hash()), txs)
+		obscurocommon.ShortAddress(m.ID), obscurocommon.ShortHash(b.Hash()), m.Resolver.HeightBlock(b), obscurocommon.ShortNonce(b.Header().Nonce), obscurocommon.ShortHash(p.Hash()), txs)
 }

--- a/integration/simulation/utils.go
+++ b/integration/simulation/utils.go
@@ -3,10 +3,11 @@ package simulation
 import (
 	"fmt"
 
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+
 	"github.com/ethereum/go-ethereum/core/types"
 
-	common3 "github.com/obscuronet/obscuro-playground/go/common"
-	common2 "github.com/obscuronet/obscuro-playground/go/obscuronode/common"
+	"github.com/obscuronet/obscuro-playground/go/common"
 	ethereum_mock "github.com/obscuronet/obscuro-playground/integration/ethereummock"
 )
 
@@ -14,12 +15,12 @@ func printBlock(b *types.Block, m ethereum_mock.Node) string {
 	// This is just for printing
 	var txs []string
 	for _, tx := range b.Transactions() {
-		t := common3.TxData(tx)
-		if t.TxType == common3.RollupTx {
-			r := common2.DecodeRollup(t.Rollup)
-			txs = append(txs, fmt.Sprintf("r_%d", common3.ShortHash(r.Hash())))
-		} else if t.TxType == common3.DepositTx {
-			txs = append(txs, fmt.Sprintf("deposit(%d=%d)", common3.ShortAddress(t.Dest), t.Amount))
+		t := common.TxData(tx)
+		if t.TxType == common.RollupTx {
+			r := nodecommon.DecodeRollup(t.Rollup)
+			txs = append(txs, fmt.Sprintf("r_%d", common.ShortHash(r.Hash())))
+		} else if t.TxType == common.DepositTx {
+			txs = append(txs, fmt.Sprintf("deposit(%d=%d)", common.ShortAddress(t.Dest), t.Amount))
 		}
 	}
 	p, f := m.Resolver.ParentBlock(b)
@@ -28,5 +29,5 @@ func printBlock(b *types.Block, m ethereum_mock.Node) string {
 	}
 
 	return fmt.Sprintf("> M%d: create b_%d(Height=%d, Nonce=%d)[parent=b_%d]. Txs: %v",
-		common3.ShortAddress(m.ID), common3.ShortHash(b.Hash()), m.Resolver.HeightBlock(b), common3.ShortNonce(b.Header().Nonce), common3.ShortHash(p.Hash()), txs)
+		common.ShortAddress(m.ID), common.ShortHash(b.Hash()), m.Resolver.HeightBlock(b), common.ShortNonce(b.Header().Nonce), common.ShortHash(p.Hash()), txs)
 }


### PR DESCRIPTION
* Instead of `common2`/`common3`/etc., uses `obscurocommon` and `nodecommon` (`common` is taken by geth's `common`)
* Deletes some unused common functions
* Moves host code into host package (was previously directly under `obscuronode` directory)