### PR TITLE
Implementing the P2P interface in chans

### DIFF
--- a/go/obscuronode/host/p2p/factory.go
+++ b/go/obscuronode/host/p2p/factory.go
@@ -1,0 +1,17 @@
+package p2p
+
+// Factory allows building different types of P2P networks
+// this is commonly used for its injection / lazy-instantiation capabilities
+type Factory struct {
+	p2p func(ourAddress string, allAddresses []string) P2P
+}
+
+// NewP2P returns a new P2P instance
+func (f *Factory) NewP2P(address string, addresses []string) P2P {
+	return f.p2p(address, addresses)
+}
+
+// NewP2PFactory creates a new Factory givng the P2P init function
+func NewP2PFactory(p2p func(ourAddress string, allAddresses []string) P2P) *Factory {
+	return &Factory{p2p: p2p}
+}

--- a/go/obscuronode/host/p2p/local_p2p.go
+++ b/go/obscuronode/host/p2p/local_p2p.go
@@ -1,0 +1,124 @@
+package p2p
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/obscuronet/obscuro-playground/go/log"
+	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+)
+
+// fake multicast network
+var networkLayer = make(map[string]chan []byte)
+
+// localP2PImpl implements the P2P in a channel based approach
+type localP2PImpl struct {
+	address       string
+	peerAddresses []string
+	txChan        chan nodecommon.EncryptedTx
+	rollupChan    chan obscurocommon.EncodedRollup
+}
+
+// NewLocalP2P returns a new P2P object that runs locally using channels.
+func NewLocalP2P(ourAddress string, allAddresses []string) P2P {
+	// We filter out our P2P address if it's contained in the list of all P2P addresses.
+	var peerAddresses []string
+	for _, a := range allAddresses {
+		if a != ourAddress {
+			peerAddresses = append(peerAddresses, a)
+		}
+	}
+
+	// ensure all network chans have been created
+	if _, found := networkLayer[ourAddress]; !found {
+		networkLayer[ourAddress] = make(chan []byte, 1000)
+	}
+
+	return &localP2PImpl{
+		address:       ourAddress,
+		peerAddresses: peerAddresses,
+	}
+}
+
+func (l *localP2PImpl) Listen(txChan chan nodecommon.EncryptedTx, rollupChan chan obscurocommon.EncodedRollup) {
+	l.txChan = txChan
+	l.rollupChan = rollupChan
+	listener := networkLayer[l.address]
+	go func() {
+		for {
+			data, ok := <-listener
+			if !ok {
+				return
+			}
+			l.handle(data)
+		}
+	}()
+}
+
+// StopListening closes the channels
+func (l *localP2PImpl) StopListening() {
+	close(l.txChan)
+	close(l.rollupChan)
+	close(networkLayer[l.address])
+}
+
+func (l *localP2PImpl) BroadcastTx(bytes []byte) {
+	l.broadcast(Tx, bytes)
+}
+
+func (l *localP2PImpl) BroadcastRollup(bytes []byte) {
+	l.broadcast(Rollup, bytes)
+}
+
+// SendBytes issues bytes across the network
+func (l *localP2PImpl) SendBytes(address string, data []byte) {
+	networkLayer[address] <- data
+}
+
+// Creates a P2P message and broadcasts it to all peers.
+func (l *localP2PImpl) broadcast(msgType Type, bytes []byte) {
+	msg := Message{Type: msgType, MsgContents: bytes}
+	msgEncoded, err := rlp.EncodeToBytes(msg)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, a := range l.peerAddresses {
+		address := a
+		l.SendBytes(address, msgEncoded)
+	}
+}
+
+// Receives and decodes a P2P message, and pushes it to the correct channel.
+func (l *localP2PImpl) handle(data []byte) {
+	msg := Message{}
+	err := rlp.DecodeBytes(data, &msg)
+	if err != nil {
+		panic(err)
+	}
+
+	switch msg.Type {
+	case Tx:
+		tx := nodecommon.L2Tx{}
+		err := rlp.DecodeBytes(msg.MsgContents, &tx)
+		// We only post the transaction if it decodes correctly.
+		if err != nil {
+			log.Log(fmt.Sprintf("failed to decode transaction received from peer: %v", err))
+			break
+		}
+		l.txChan <- msg.MsgContents
+
+	case Rollup:
+		rollup := nodecommon.Rollup{}
+		err := rlp.DecodeBytes(msg.MsgContents, &rollup)
+		// We only post the rollup if it decodes correctly.
+		if err != nil {
+			log.Log(fmt.Sprintf("failed to decode rollup received from peer: %v", err))
+			break
+		}
+		l.rollupChan <- msg.MsgContents
+	default:
+		panic(msg)
+	}
+}

--- a/go/obscuronode/host/p2p/local_p2p.go
+++ b/go/obscuronode/host/p2p/local_p2p.go
@@ -9,7 +9,8 @@ import (
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 )
 
-// fake multicast network
+// networkLayer is a fake multicast network
+// it's shared across the p2p package and allows for each instance to receive comms
 var networkLayer = make(map[string]chan []byte)
 
 // localP2PImpl implements the P2P in a channel based approach
@@ -30,7 +31,7 @@ func NewLocalP2P(ourAddress string, allAddresses []string) P2P {
 		}
 	}
 
-	// ensure all network chans have been created
+	// ensure the current client network layer has been created
 	if _, found := networkLayer[ourAddress]; !found {
 		networkLayer[ourAddress] = make(chan []byte, 1000)
 	}
@@ -105,7 +106,7 @@ func (l *localP2PImpl) handle(data []byte) {
 		// We only post the transaction if it decodes correctly.
 		if err != nil {
 			log.Log(fmt.Sprintf("failed to decode transaction received from peer: %v", err))
-			break
+			return
 		}
 		l.txChan <- msg.MsgContents
 
@@ -115,7 +116,7 @@ func (l *localP2PImpl) handle(data []byte) {
 		// We only post the rollup if it decodes correctly.
 		if err != nil {
 			log.Log(fmt.Sprintf("failed to decode rollup received from peer: %v", err))
-			break
+			return
 		}
 		l.rollupChan <- msg.MsgContents
 	default:

--- a/go/obscuronode/host/p2p/p2p.go
+++ b/go/obscuronode/host/p2p/p2p.go
@@ -40,6 +40,9 @@ type P2P interface {
 	BroadcastTx([]byte)
 	// BroadcastRollup broadcasts a rollup to all network peers over P2P.
 	BroadcastRollup([]byte)
+
+	// SendBytes allows issuance of bytes to the network
+	SendBytes(address string, tx []byte)
 }
 
 // NewP2P returns a new P2P object.
@@ -165,12 +168,12 @@ func (p *p2pImpl) broadcast(msgType Type, bytes []byte) {
 	}
 
 	for _, address := range p.PeerAddresses {
-		sendBytes(address, msgEncoded)
+		p.SendBytes(address, msgEncoded)
 	}
 }
 
-// Sends the bytes over P2P to the given address.
-func sendBytes(address string, tx []byte) {
+// SendBytes Sends the bytes over P2P to the given address.
+func (p *p2pImpl) SendBytes(address string, tx []byte) {
 	conn, err := net.Dial("tcp", address)
 	if conn != nil {
 		defer func(conn net.Conn) {

--- a/integration/simulation/cmd/main.go
+++ b/integration/simulation/cmd/main.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/host/p2p"
+
 	"github.com/google/uuid"
 	"github.com/obscuronet/obscuro-playground/go/log"
 	"github.com/obscuronet/obscuro-playground/integration/simulation"
@@ -47,21 +49,14 @@ func main() {
 	avgGossipPeriod := avgBlockDuration / DefaultAverageGossipPeriodToBlockRatio
 
 	// define network params
+	p2pNetwork := p2p.NewP2P
 	stats := simulation.NewStats(numberOfNodes)
 	l1NetworkConfig := simulation.NewL1Network(avgBlockDuration, avgLatency, stats)
-	l2NetworkCfg := simulation.NewL2Network(avgBlockDuration, avgLatency)
+	l2NetworkCfg := simulation.NewL2Network(numberOfNodes, avgBlockDuration, avgLatency, p2pNetwork)
 
 	// define instances of the simulation mechanisms
 	txManager := simulation.NewTransactionManager(5, l1NetworkConfig, l2NetworkCfg, avgBlockDuration, stats)
-	sim := simulation.NewSimulation(
-		numberOfNodes,
-		l1NetworkConfig,
-		l2NetworkCfg,
-		avgBlockDuration,
-		avgGossipPeriod,
-		false,
-		stats,
-	)
+	sim := simulation.NewSimulation(numberOfNodes, l1NetworkConfig, l2NetworkCfg, avgBlockDuration, avgGossipPeriod, false, stats, p2pNetwork)
 
 	// execute the simulation
 	sim.Start(txManager, simulationTime)

--- a/integration/simulation/cmd/main.go
+++ b/integration/simulation/cmd/main.go
@@ -49,14 +49,14 @@ func main() {
 	avgGossipPeriod := avgBlockDuration / DefaultAverageGossipPeriodToBlockRatio
 
 	// define network params
-	p2pNetwork := p2p.NewP2P
+	p2pNetworkFactory := p2p.NewP2PFactory(p2p.NewP2P)
 	stats := simulation.NewStats(numberOfNodes)
 	l1NetworkConfig := simulation.NewL1Network(avgBlockDuration, avgLatency, stats)
-	l2NetworkCfg := simulation.NewL2Network(numberOfNodes, avgBlockDuration, avgLatency, p2pNetwork)
+	l2NetworkCfg := simulation.NewL2Network(numberOfNodes, avgBlockDuration, avgLatency, p2pNetworkFactory)
 
 	// define instances of the simulation mechanisms
 	txManager := simulation.NewTransactionManager(5, l1NetworkConfig, l2NetworkCfg, avgBlockDuration, stats)
-	sim := simulation.NewSimulation(numberOfNodes, l1NetworkConfig, l2NetworkCfg, avgBlockDuration, avgGossipPeriod, false, stats, p2pNetwork)
+	sim := simulation.NewSimulation(numberOfNodes, l1NetworkConfig, l2NetworkCfg, avgBlockDuration, avgGossipPeriod, false, stats, p2pNetworkFactory)
 
 	// execute the simulation
 	sim.Start(txManager, simulationTime)

--- a/integration/simulation/l2_network.go
+++ b/integration/simulation/l2_network.go
@@ -23,19 +23,14 @@ type L2NetworkCfg struct {
 }
 
 // NewL2Network returns an instance of a configured L2 Network (no nodes)
-func NewL2Network(
-	nrNodes int,
-	avgBlockDuration uint64,
-	avgLatency uint64,
-	newP2P func(ourAddress string, allAddresses []string) p2p.P2P,
-) *L2NetworkCfg {
+func NewL2Network(nrNodes int, avgBlockDuration uint64, avgLatency uint64, p2pFactory *p2p.Factory) *L2NetworkCfg {
 	// We generate the P2P addresses for each node on the network.
 	var nodeAddresses []string
 	for i := 1; i <= nrNodes; i++ {
 		nodeAddresses = append(nodeAddresses, fmt.Sprintf("localhost:%d", P2P_START_PORT+i))
 	}
 
-	p2pNetwork := newP2P(fmt.Sprintf("localhost:%d", P2P_START_PORT+100), nodeAddresses)
+	p2pNetwork := p2pFactory.NewP2P(fmt.Sprintf("localhost:%d", P2P_START_PORT+100), nodeAddresses)
 	p2pNetwork.Listen(nil, nil)
 
 	return &L2NetworkCfg{

--- a/integration/simulation/l2_network.go
+++ b/integration/simulation/l2_network.go
@@ -35,13 +35,13 @@ func NewL2Network(
 		nodeAddresses = append(nodeAddresses, fmt.Sprintf("localhost:%d", P2P_START_PORT+i))
 	}
 
-	p2p := newP2P("localhost:11000", nodeAddresses)
-	p2p.Listen(nil, nil)
+	p2pNetwork := newP2P(fmt.Sprintf("localhost:%d", P2P_START_PORT+100), nodeAddresses)
+	p2pNetwork.Listen(nil, nil)
 
 	return &L2NetworkCfg{
 		avgLatency:       avgLatency,
 		avgBlockDuration: avgBlockDuration,
-		p2p:              p2p,
+		p2p:              p2pNetwork,
 		nodeAddresses:    nodeAddresses,
 	}
 }

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -44,7 +44,7 @@ func NewSimulation(
 	gossipPeriod uint64,
 	localEnclave bool,
 	stats *Stats,
-	newP2P func(ourAddress string, allAddresses []string) p2p.P2P,
+	p2pFactory *p2p.Factory,
 ) *Simulation {
 	l1NodeCfg := ethereum_mock.MiningConfig{
 		PowTime: func() uint64 {
@@ -81,7 +81,7 @@ func NewSimulation(
 		}
 
 		// create a layer 2 node
-		aggP2P := newP2P(l2NetworkCfg.nodeAddresses[i-1], l2NetworkCfg.nodeAddresses)
+		aggP2P := p2pFactory.NewP2P(l2NetworkCfg.nodeAddresses[i-1], l2NetworkCfg.nodeAddresses)
 		agg := host.NewAgg(nodeID, l2NodeCfg, nil, stats, genesis, enclaveClient, aggP2P)
 		l2NetworkCfg.nodes = append(l2NetworkCfg.nodes, &agg)
 

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -44,6 +44,7 @@ func NewSimulation(
 	gossipPeriod uint64,
 	localEnclave bool,
 	stats *Stats,
+	newP2P func(ourAddress string, allAddresses []string) p2p.P2P,
 ) *Simulation {
 	l1NodeCfg := ethereum_mock.MiningConfig{
 		PowTime: func() uint64 {
@@ -57,11 +58,6 @@ func NewSimulation(
 	}
 
 	l2NodeCfg := host.AggregatorCfg{ClientRPCTimeoutSecs: host.ClientRPCTimeoutSecs, GossipRoundDuration: gossipPeriod}
-
-	// We generate the P2P addresses for each node on the network.
-	for i := 1; i <= nrNodes; i++ {
-		l2NetworkCfg.nodeAddresses = append(l2NetworkCfg.nodeAddresses, fmt.Sprintf("localhost:%d", P2P_START_PORT+i))
-	}
 
 	for i := 1; i <= nrNodes; i++ {
 		genesis := false
@@ -85,7 +81,7 @@ func NewSimulation(
 		}
 
 		// create a layer 2 node
-		aggP2P := p2p.NewP2P(l2NetworkCfg.nodeAddresses[i-1], l2NetworkCfg.nodeAddresses)
+		aggP2P := newP2P(l2NetworkCfg.nodeAddresses[i-1], l2NetworkCfg.nodeAddresses)
 		agg := host.NewAgg(nodeID, l2NodeCfg, nil, stats, genesis, enclaveClient, aggP2P)
 		l2NetworkCfg.nodes = append(l2NetworkCfg.nodes, &agg)
 

--- a/integration/simulation/simulation_test.go
+++ b/integration/simulation/simulation_test.go
@@ -40,10 +40,10 @@ func TestSimulation(t *testing.T) {
 	avgGossipPeriod := avgBlockDurationUSecs / 3
 
 	// define network params
-	p2pNetwork := p2p.NewP2P
+	p2pNetworkFactory := p2p.NewP2PFactory(p2p.NewP2P)
 	stats := NewStats(numberOfNodes)
 	l1NetworkConfig := NewL1Network(avgBlockDurationUSecs, avgLatency, stats)
-	l2NetworkCfg := NewL2Network(numberOfNodes, avgBlockDurationUSecs, avgLatency, p2pNetwork)
+	l2NetworkCfg := NewL2Network(numberOfNodes, avgBlockDurationUSecs, avgLatency, p2pNetworkFactory)
 
 	// define instances of the simulation mechanisms
 	txManager := NewTransactionManager(5, l1NetworkConfig, l2NetworkCfg, avgBlockDurationUSecs, stats)
@@ -55,7 +55,7 @@ func TestSimulation(t *testing.T) {
 		avgGossipPeriod,
 		false,
 		stats,
-		p2pNetwork,
+		p2pNetworkFactory,
 	)
 
 	// execute the simulation

--- a/integration/simulation/simulation_test.go
+++ b/integration/simulation/simulation_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/host/p2p"
+
 	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
@@ -38,9 +40,10 @@ func TestSimulation(t *testing.T) {
 	avgGossipPeriod := avgBlockDurationUSecs / 3
 
 	// define network params
+	p2pNetwork := p2p.NewP2P
 	stats := NewStats(numberOfNodes)
 	l1NetworkConfig := NewL1Network(avgBlockDurationUSecs, avgLatency, stats)
-	l2NetworkCfg := NewL2Network(avgBlockDurationUSecs, avgLatency)
+	l2NetworkCfg := NewL2Network(numberOfNodes, avgBlockDurationUSecs, avgLatency, p2pNetwork)
 
 	// define instances of the simulation mechanisms
 	txManager := NewTransactionManager(5, l1NetworkConfig, l2NetworkCfg, avgBlockDurationUSecs, stats)
@@ -52,6 +55,7 @@ func TestSimulation(t *testing.T) {
 		avgGossipPeriod,
 		false,
 		stats,
+		p2pNetwork,
 	)
 
 	// execute the simulation


### PR DESCRIPTION
Easier to debug.
L2 Network now uses the P2P library instead of hardcoding the comunication.