### PR TITLE
Pushes waiting for enclaves start-up to inside host. More graceful handling of connection errors.

### DIFF
--- a/go/obscuronode/host/host.go
+++ b/go/obscuronode/host/host.go
@@ -104,6 +104,8 @@ func NewAgg(
 
 // Start initializes the main loop of the node
 func (a *Node) Start() {
+	a.waitForEnclave()
+
 	a.p2p.Listen(a.txP2PCh, a.rollupsP2PCh)
 	defer a.p2p.StopListening()
 
@@ -125,6 +127,20 @@ func (a *Node) Start() {
 
 	// todo create a channel between request secret and start processing
 	a.startProcessing(allBlocks)
+}
+
+// Waits for enclave to be available, printing a wait message every two seconds.
+func (a *Node) waitForEnclave() {
+	counter := 0
+	for a.Enclave.IsReady() != nil {
+		if counter >= 20 {
+			log.Log(fmt.Sprintf(">   Agg%d: Waiting for enclave. Error: %v", obscurocommon.ShortAddress(a.ID), a.Enclave.IsReady()))
+			counter = 0
+		}
+
+		time.Sleep(100 * time.Millisecond)
+		counter++
+	}
 }
 
 // Waits for blocks from the L1 node, printing a wait message every two seconds.

--- a/go/obscuronode/host/main/main.go
+++ b/go/obscuronode/host/main/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/host/p2p"
@@ -21,26 +20,7 @@ func main() {
 	aggP2P := p2p.NewP2P(*config.ourP2PAddr, config.peerP2PAddrs)
 	agg := host.NewAgg(nodeID, hostCfg, l1NodeDummy{}, nil, *config.isGenesis, enclaveClient, aggP2P)
 
-	waitForEnclave(agg, *config.enclaveAddr)
 	agg.Start()
-}
-
-// Waits for the enclave server to start, printing a wait message every two seconds.
-func waitForEnclave(agg host.Node, enclaveAddr string) {
-	i := 0
-	for {
-		if agg.Enclave.IsReady() == nil {
-			fmt.Printf("Connected to enclave server on address %s.\n", enclaveAddr)
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-		i++
-
-		if i >= 20 {
-			fmt.Printf("Trying to connect to enclave server on address %s...\n", enclaveAddr)
-			i = 0
-		}
-	}
 }
 
 // TODO - Replace this dummy once we have implemented communication with L1 nodes.

--- a/go/obscuronode/host/p2p/p2p.go
+++ b/go/obscuronode/host/p2p/p2p.go
@@ -74,17 +74,15 @@ func (p *p2pImpl) Listen(txP2PCh chan nodecommon.EncryptedTx, rollupsP2PCh chan 
 		panic(err)
 	}
 
-	i := int32(0)
-	p.listenerInterrupt = &i
+	atomic.StoreInt32(p.listenerInterrupt, 0)
 	p.listener = listener
 
 	go p.handleConnections(txP2PCh, rollupsP2PCh, listener)
 }
 
 func (p *p2pImpl) StopListening() {
-	i := int32(1)
-	p.listenerInterrupt = &i
-
+	atomic.StoreInt32(p.listenerInterrupt, 1)
+	
 	if p.listener != nil {
 		if err := p.listener.Close(); err != nil {
 			log.Log(fmt.Sprintf("failed to close transaction P2P listener cleanly: %v", err))

--- a/go/obscuronode/host/p2p/p2p.go
+++ b/go/obscuronode/host/p2p/p2p.go
@@ -82,7 +82,7 @@ func (p *p2pImpl) Listen(txP2PCh chan nodecommon.EncryptedTx, rollupsP2PCh chan 
 
 func (p *p2pImpl) StopListening() {
 	atomic.StoreInt32(p.listenerInterrupt, 1)
-	
+
 	if p.listener != nil {
 		if err := p.listener.Close(); err != nil {
 			log.Log(fmt.Sprintf("failed to close transaction P2P listener cleanly: %v", err))

--- a/go/obscuronode/host/p2p/p2p.go
+++ b/go/obscuronode/host/p2p/p2p.go
@@ -78,7 +78,7 @@ func (p *p2pImpl) Listen(txP2PCh chan nodecommon.EncryptedTx, rollupsP2PCh chan 
 	p.listenerInterrupt = &i
 	p.listener = listener
 
-	go p.handleConnections(txP2PCh, rollupsP2PCh, listener)
+	go p.handleConnections(txP2PCh, rollupsP2PCh)
 }
 
 func (p *p2pImpl) StopListening() {
@@ -100,9 +100,9 @@ func (p *p2pImpl) BroadcastRollup(bytes []byte) {
 }
 
 // Listens for connections and handles them in a separate goroutine.
-func (p *p2pImpl) handleConnections(txP2PCh chan nodecommon.EncryptedTx, rollupsP2PCh chan obscurocommon.EncodedRollup, listener net.Listener) {
+func (p *p2pImpl) handleConnections(txP2PCh chan nodecommon.EncryptedTx, rollupsP2PCh chan obscurocommon.EncodedRollup) {
 	for {
-		conn, err := listener.Accept()
+		conn, err := p.listener.Accept()
 		if err != nil {
 			if atomic.LoadInt32(p.listenerInterrupt) != 1 {
 				panic(fmt.Errorf("host could not handle P2P connection: %w", err))

--- a/go/obscuronode/host/p2p/p2p.go
+++ b/go/obscuronode/host/p2p/p2p.go
@@ -105,7 +105,8 @@ func (p *p2pImpl) handleConnections(txP2PCh chan nodecommon.EncryptedTx, rollups
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
-			panic(fmt.Errorf("could not accept any further connections: %w", err))
+			log.Log(fmt.Sprintf("host is not accepting any further P2P connections: %v", err))
+			return
 		}
 		go handle(conn, txP2PCh, rollupsP2PCh)
 	}
@@ -180,7 +181,8 @@ func sendBytes(address string, tx []byte) {
 		}(conn)
 	}
 	if err != nil {
-		panic(err)
+		log.Log(fmt.Sprintf("could not send message to peer on address %s: %v", address, err))
+		return
 	}
 
 	_, err = conn.Write(tx)

--- a/go/obscuronode/host/p2p/p2p.go
+++ b/go/obscuronode/host/p2p/p2p.go
@@ -74,7 +74,8 @@ func (p *p2pImpl) Listen(txP2PCh chan nodecommon.EncryptedTx, rollupsP2PCh chan 
 		panic(err)
 	}
 
-	atomic.StoreInt32(p.listenerInterrupt, 0)
+	i := int32(0)
+	p.listenerInterrupt = &i
 	p.listener = listener
 
 	go p.handleConnections(txP2PCh, rollupsP2PCh, listener)

--- a/integration/simulation/l2_network.go
+++ b/integration/simulation/l2_network.go
@@ -1,8 +1,11 @@
 package simulation
 
 import (
+	"fmt"
 	"net"
 	"time"
+
+	"github.com/obscuronet/obscuro-playground/go/log"
 
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/host/p2p"
@@ -47,9 +50,9 @@ func (cfg *L2NetworkCfg) BroadcastTx(tx nodecommon.EncryptedTx) {
 func broadcastBytes(address string, tx []byte) {
 	conn, err := net.Dial("tcp", address)
 	if err != nil {
-		panic(err)
+		log.Log(fmt.Sprintf("could not send message to peer on address %s: %v", address, err))
+		return
 	}
-
 	defer func(conn net.Conn) {
 		if err := conn.Close(); err != nil {
 			panic(err)

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -96,8 +96,6 @@ func NewSimulation(
 		agg.L1Node = &miner
 	}
 
-	waitForEnclaveServers(l2NetworkCfg)
-
 	log.Log(fmt.Sprintf("Genesis block: b_%d.", obscurocommon.ShortHash(obscurocommon.GenesisBlock.Hash())))
 
 	return &Simulation{
@@ -149,16 +147,4 @@ func (s *Simulation) Stop() {
 	// stop L2 first and then L1
 	go s.l2Network.Stop()
 	go s.l1Network.Stop()
-}
-
-// Returns once all the enclave servers are ready.
-func waitForEnclaveServers(l2NetworkCfg *L2NetworkCfg) {
-	for _, node := range l2NetworkCfg.nodes {
-		for {
-			if node.Enclave.IsReady() == nil {
-				break
-			}
-			time.Sleep(10 * time.Millisecond)
-		}
-	}
 }


### PR DESCRIPTION
We were panicking too much on connection errors before. There were lots of spurious errors at the end of the simulation, when the listeners were being closed and failed connections are to be accepted.