### PR TITLE
Refactor withdrawals in preparation for evm integration

### DIFF
--- a/go/obscuronode/enclave/db.go
+++ b/go/obscuronode/enclave/db.go
@@ -39,9 +39,9 @@ type DB interface {
 	// SetBlockStateNewRollup persists the state after ingesting the L1 block with the given hash that contains a new rollup
 	SetBlockStateNewRollup(hash obscurocommon.L1RootHash, state *blockState)
 	// FetchRollupState returns the state after adding the rollup with the given hash
-	FetchRollupState(hash obscurocommon.L2RootHash) State
+	FetchRollupState(hash obscurocommon.L2RootHash) *State
 	// SetRollupState persists the state after adding the rollup with the given hash
-	SetRollupState(hash obscurocommon.L2RootHash, state State)
+	SetRollupState(hash obscurocommon.L2RootHash, state *State)
 
 	// FetchMempoolTxs returns all L2 transactions in the mempool
 	FetchMempoolTxs() []nodecommon.L2Tx
@@ -79,7 +79,7 @@ type inMemoryDB struct {
 	txMutex    sync.RWMutex // Controls access to `txsPerRollupCache`
 
 	statePerBlock     map[obscurocommon.L1RootHash]*blockState
-	statePerRollup    map[obscurocommon.L2RootHash]State
+	statePerRollup    map[obscurocommon.L2RootHash]*State
 	headBlock         obscurocommon.L1RootHash
 	rollupsByHeight   map[uint64][]*Rollup
 	rollups           map[obscurocommon.L2RootHash]*Rollup
@@ -98,7 +98,7 @@ func NewInMemoryDB() DB {
 		rollups:           make(map[obscurocommon.L2RootHash]*Rollup),
 		mempool:           make(map[common.Hash]nodecommon.L2Tx),
 		mpMutex:           sync.RWMutex{},
-		statePerRollup:    make(map[obscurocommon.L2RootHash]State),
+		statePerRollup:    make(map[obscurocommon.L2RootHash]*State),
 		blockCache:        map[obscurocommon.L1RootHash]*blockAndHeight{},
 		blockMutex:        sync.RWMutex{},
 		txsPerRollupCache: make(map[obscurocommon.L2RootHash]map[common.Hash]nodecommon.L2Tx),
@@ -144,7 +144,7 @@ func (db *inMemoryDB) SetBlockStateNewRollup(hash obscurocommon.L1RootHash, stat
 	db.headBlock = hash
 }
 
-func (db *inMemoryDB) SetRollupState(hash obscurocommon.L2RootHash, state State) {
+func (db *inMemoryDB) SetRollupState(hash obscurocommon.L2RootHash, state *State) {
 	db.stateMutex.Lock()
 	defer db.stateMutex.Unlock()
 
@@ -184,7 +184,7 @@ func (db *inMemoryDB) FetchRollups(height uint64) []*Rollup {
 	return db.rollupsByHeight[height]
 }
 
-func (db *inMemoryDB) FetchRollupState(hash obscurocommon.L2RootHash) State {
+func (db *inMemoryDB) FetchRollupState(hash obscurocommon.L2RootHash) *State {
 	db.stateMutex.RLock()
 	defer db.stateMutex.RUnlock()
 

--- a/go/obscuronode/enclave/storage.go
+++ b/go/obscuronode/enclave/storage.go
@@ -51,9 +51,9 @@ type Storage interface {
 	// SetBlockState persists the state after ingesting the L1 block with the given hash
 	SetBlockState(hash obscurocommon.L1RootHash, state *blockState)
 	// FetchRollupState returns the state after adding the rollup with the given hash
-	FetchRollupState(hash obscurocommon.L2RootHash) State
+	FetchRollupState(hash obscurocommon.L2RootHash) *State
 	// SetRollupState persists the state after adding the rollup with the given hash
-	SetRollupState(hash obscurocommon.L2RootHash, state State)
+	SetRollupState(hash obscurocommon.L2RootHash, state *State)
 
 	// FetchMempoolTxs returns all L2 transactions in the mempool
 	FetchMempoolTxs() []nodecommon.L2Tx
@@ -108,7 +108,7 @@ func (s *storageImpl) SetBlockState(hash obscurocommon.L1RootHash, state *blockS
 	}
 }
 
-func (s *storageImpl) SetRollupState(hash obscurocommon.L2RootHash, state State) {
+func (s *storageImpl) SetRollupState(hash obscurocommon.L2RootHash, state *State) {
 	s.assertSecretAvailable()
 	s.db.SetRollupState(hash, state)
 }
@@ -134,7 +134,7 @@ func (s *storageImpl) FetchRollups(height uint64) []*Rollup {
 	return s.db.FetchRollups(height)
 }
 
-func (s *storageImpl) FetchRollupState(hash obscurocommon.L2RootHash) State {
+func (s *storageImpl) FetchRollupState(hash obscurocommon.L2RootHash) *State {
 	s.assertSecretAvailable()
 	return s.db.FetchRollupState(hash)
 }

--- a/go/obscuronode/enclave/utils.go
+++ b/go/obscuronode/enclave/utils.go
@@ -94,3 +94,12 @@ func printTx(t nodecommon.L2Tx, txsString []string) []string {
 	}
 	return txsString
 }
+
+func contains(s []obscurocommon.TxHash, e obscurocommon.TxHash) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -151,9 +151,12 @@ func checkBlockchainOfObscuroNode(t *testing.T, node *host.Node, minObscuroHeigh
 	}
 
 	totalL2Blocks := s.Stats.NoL2Blocks[node.ID]
-	efficiencyL2 := float64(totalL2Blocks-l2Height) / float64(totalL2Blocks)
-	if efficiencyL2 > s.Params.L2EfficiencyThreshold {
-		t.Errorf("Node %d. Efficiency in L2 is %f. Expected:%f", obscurocommon.ShortAddress(node.ID), efficiencyL2, s.Params.L2EfficiencyThreshold)
+	// in case the blockchain has advanced above what was collected, there is no longer a point to this check
+	if l2Height <= totalL2Blocks {
+		efficiencyL2 := float64(totalL2Blocks-l2Height) / float64(totalL2Blocks)
+		if efficiencyL2 > s.Params.L2EfficiencyThreshold {
+			t.Errorf("Node %d. Efficiency in L2 is %f. Expected:%f", obscurocommon.ShortAddress(node.ID), efficiencyL2, s.Params.L2EfficiencyThreshold)
+		}
 	}
 
 	// check that the pobi protocol doesn't waste too many blocks.


### PR DESCRIPTION
The main difference is that "Withdrawals" are now somewhere inside the mock EVM state, and are transformed into withdrawal instructions in a post processing step