### PR TITLE
Start/Stop tx injector

### DIFF
--- a/go/obscuronode/host/host.go
+++ b/go/obscuronode/host/host.go
@@ -19,7 +19,7 @@ const ClientRPCTimeoutSecs = 5
 // todo - this has to be replaced with a proper cfg framework
 type AggregatorCfg struct {
 	// duration of the gossip round
-	GossipRoundDuration uint64
+	GossipRoundDuration time.Duration
 	// timeout duration in seconds for RPC requests to the enclave service
 	ClientRPCTimeoutSecs uint64
 }
@@ -340,7 +340,7 @@ func (a *Node) processBlocks(blocks []obscurocommon.EncodedBlock, interrupt *int
 	if result.ProducedRollup.Header != nil {
 		a.P2p.BroadcastRollup(nodecommon.EncodeRollup(result.ProducedRollup.ToRollup()))
 
-		obscurocommon.ScheduleInterrupt(a.cfg.GossipRoundDuration, interrupt, a.handleHeader(result))
+		obscurocommon.ScheduleInterrupt(uint64(a.cfg.GossipRoundDuration.Nanoseconds()), interrupt, a.handleHeader(result))
 	}
 }
 

--- a/go/obscuronode/host/main/main.go
+++ b/go/obscuronode/host/main/main.go
@@ -19,7 +19,7 @@ func main() {
 	config := parseCLIArgs()
 
 	nodeID := common.BytesToAddress([]byte(*config.nodeID))
-	hostCfg := host.AggregatorCfg{GossipRoundDuration: *config.gossipRoundNanos, ClientRPCTimeoutSecs: *config.rpcTimeoutSecs}
+	hostCfg := host.AggregatorCfg{GossipRoundDuration: time.Duration(*config.gossipRoundNanos), ClientRPCTimeoutSecs: *config.rpcTimeoutSecs}
 	enclaveClient := host.NewEnclaveRPCClient(*config.enclaveAddr, host.ClientRPCTimeoutSecs*time.Second, nodeID)
 	aggP2P := p2p.NewSocketP2PLayer(*config.ourP2PAddr, config.peerP2PAddrs)
 	agg := host.NewObscuroAggregator(nodeID, hostCfg, l1NodeDummy{}, nil, *config.isGenesis, enclaveClient, aggP2P)

--- a/integration/ethereummock/mock_l1_network.go
+++ b/integration/ethereummock/mock_l1_network.go
@@ -2,6 +2,7 @@ package ethereummock
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
@@ -19,14 +20,14 @@ type MockEthNetwork struct {
 	AllNodes []*Node
 
 	// config
-	avgLatency       uint64
-	avgBlockDuration uint64
+	avgLatency       time.Duration
+	avgBlockDuration time.Duration
 
 	Stats host.StatsCollector
 }
 
 // NewMockEthNetwork returns an instance of a configured L1 Network (no nodes)
-func NewMockEthNetwork(avgBlockDuration uint64, avgLatency uint64, stats host.StatsCollector) *MockEthNetwork {
+func NewMockEthNetwork(avgBlockDuration time.Duration, avgLatency time.Duration, stats host.StatsCollector) *MockEthNetwork {
 	return &MockEthNetwork{
 		Stats:            stats,
 		avgLatency:       avgLatency,
@@ -64,7 +65,7 @@ func (n *MockEthNetwork) BroadcastTx(tx obscurocommon.EncodedL1Tx) {
 
 // delay returns an expected delay on the l1 network
 func (n *MockEthNetwork) delay() uint64 {
-	return obscurocommon.RndBtw(n.avgLatency/10, 2*n.avgLatency)
+	return obscurocommon.RndBtw(uint64(n.avgLatency.Nanoseconds()/10), uint64(2*n.avgLatency.Nanoseconds()))
 }
 
 func printBlock(b *types.Block, m Node) string {

--- a/integration/simulation/network/basicsocket.go
+++ b/integration/simulation/network/basicsocket.go
@@ -56,7 +56,7 @@ func (n *basicNetworkOfSocketNodes) Create(params params.SimParams, stats *stats
 		}
 
 		// create the in memory l1 and l2 node
-		miner := createMockEthNode(int64(i), params.NumberOfNodes, params.AvgBlockDurationUSecs, params.AvgNetworkLatency, stats)
+		miner := createMockEthNode(int64(i), params.NumberOfNodes, params.AvgBlockDuration, params.AvgNetworkLatency, stats)
 		agg := createSocketObscuroNode(int64(i), genesis, params.AvgGossipPeriod, stats, nodeP2pAddrs[i], nodeP2pAddrs, enclavePort)
 
 		// and connect them to each other
@@ -83,14 +83,14 @@ func (n *basicNetworkOfSocketNodes) Create(params params.SimParams, stats *stats
 	for _, m := range n.ethNodes {
 		t := m
 		go t.Start()
-		time.Sleep(time.Duration(params.AvgBlockDurationUSecs / 8))
+		time.Sleep(params.AvgBlockDuration / 8)
 	}
 
-	time.Sleep(time.Duration(params.AvgBlockDurationUSecs * 20))
+	time.Sleep(params.AvgBlockDuration * 20)
 	for _, m := range n.obscuroNodes {
 		t := m
 		go t.Start()
-		time.Sleep(time.Duration(params.AvgBlockDurationUSecs / 3))
+		time.Sleep(params.AvgBlockDuration / 3)
 	}
 
 	return l1Clients, n.obscuroNodes, nodeP2pAddrs

--- a/integration/simulation/network/dockerenclave.go
+++ b/integration/simulation/network/dockerenclave.go
@@ -47,7 +47,7 @@ func (n *basicNetworkOfNodesWithDockerEnclave) Create(params params.SimParams, s
 
 		// create the in memory l1 and l2 node
 		enclavePort := uint64(EnclaveStartPort + i - 1)
-		miner := createMockEthNode(int64(i), params.NumberOfNodes, params.AvgBlockDurationUSecs, params.AvgNetworkLatency, stats)
+		miner := createMockEthNode(int64(i), params.NumberOfNodes, params.AvgBlockDuration, params.AvgNetworkLatency, stats)
 		agg := createSocketObscuroNode(int64(i), genesis, params.AvgGossipPeriod, stats, nodeP2pAddrs[i], nodeP2pAddrs, enclavePort)
 
 		// and connect them to each other
@@ -75,14 +75,14 @@ func (n *basicNetworkOfNodesWithDockerEnclave) Create(params params.SimParams, s
 	for _, m := range n.ethNodes {
 		t := m
 		go t.Start()
-		time.Sleep(time.Duration(params.AvgBlockDurationUSecs / 8))
+		time.Sleep(params.AvgBlockDuration / 8)
 	}
 
-	time.Sleep(time.Duration(params.AvgBlockDurationUSecs * 20))
+	time.Sleep(params.AvgBlockDuration * 20)
 	for _, m := range n.obscuroNodes {
 		t := m
 		go t.Start()
-		time.Sleep(time.Duration(params.AvgBlockDurationUSecs / 3))
+		time.Sleep(params.AvgBlockDuration / 3)
 	}
 
 	return l1Clients, n.obscuroNodes, nodeP2pAddrs

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -39,8 +39,8 @@ func (n *basicNetworkOfInMemoryNodes) Create(params params.SimParams, stats *sta
 		}
 
 		// create the in memory l1 and l2 node
-		miner := createMockEthNode(int64(i), params.NumberOfNodes, params.AvgBlockDurationUSecs, params.AvgNetworkLatency, stats)
-		agg := createInMemObscuroNode(int64(i), genesis, params.AvgGossipPeriod, params.AvgBlockDurationUSecs, params.AvgNetworkLatency, stats)
+		miner := createMockEthNode(int64(i), params.NumberOfNodes, params.AvgBlockDuration, params.AvgNetworkLatency, stats)
+		agg := createInMemObscuroNode(int64(i), genesis, params.AvgGossipPeriod, params.AvgBlockDuration, params.AvgNetworkLatency, stats)
 
 		// and connect them to each other
 		agg.ConnectToEthNode(miner)
@@ -68,14 +68,14 @@ func (n *basicNetworkOfInMemoryNodes) Create(params params.SimParams, stats *sta
 	for _, m := range n.ethNodes {
 		t := m
 		go t.Start()
-		time.Sleep(time.Duration(params.AvgBlockDurationUSecs / 8))
+		time.Sleep(params.AvgBlockDuration / 8)
 	}
 
-	time.Sleep(time.Duration(params.AvgBlockDurationUSecs * 20))
+	time.Sleep(params.AvgBlockDuration * 20)
 	for _, m := range n.obscuroNodes {
 		t := m
 		go t.Start()
-		time.Sleep(time.Duration(params.AvgBlockDurationUSecs / 3))
+		time.Sleep(params.AvgBlockDuration / 3)
 	}
 
 	return l1Clients, n.obscuroNodes, nil

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -23,17 +23,17 @@ const (
 	EnclaveStartPort = 11000
 )
 
-func createMockEthNode(id int64, nrNodes int, avgBlockDurationUSecs time.Duration, avgNetworkLatency time.Duration, stats *stats.Stats) *ethereum_mock.Node {
-	mockEthNetwork := ethereum_mock.NewMockEthNetwork(avgBlockDurationUSecs, avgNetworkLatency, stats)
-	ethereumMockCfg := defaultMockEthNodeCfg(nrNodes, avgBlockDurationUSecs)
+func createMockEthNode(id int64, nrNodes int, avgBlockDuration time.Duration, avgNetworkLatency time.Duration, stats *stats.Stats) *ethereum_mock.Node {
+	mockEthNetwork := ethereum_mock.NewMockEthNetwork(avgBlockDuration, avgNetworkLatency, stats)
+	ethereumMockCfg := defaultMockEthNodeCfg(nrNodes, avgBlockDuration)
 	// create an in memory mock ethereum node responsible with notifying the layer 2 node about blocks
 	miner := ethereum_mock.NewMiner(common.BigToAddress(big.NewInt(id)), ethereumMockCfg, mockEthNetwork, stats)
 	mockEthNetwork.CurrentNode = &miner
 	return &miner
 }
 
-func createInMemObscuroNode(id int64, genesis bool, avgGossipPeriod time.Duration, avgBlockDurationUSecs time.Duration, avgNetworkLatency time.Duration, stats *stats.Stats) *host.Node {
-	obscuroInMemNetwork := p2p2.NewMockP2P(avgBlockDurationUSecs, avgNetworkLatency)
+func createInMemObscuroNode(id int64, genesis bool, avgGossipPeriod time.Duration, avgBlockDuration time.Duration, avgNetworkLatency time.Duration, stats *stats.Stats) *host.Node {
+	obscuroInMemNetwork := p2p2.NewMockP2P(avgBlockDuration, avgNetworkLatency)
 
 	obscuroNodeCfg := defaultObscuroNodeCfg(avgGossipPeriod)
 

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -23,7 +23,7 @@ const (
 	EnclaveStartPort = 11000
 )
 
-func createMockEthNode(id int64, nrNodes int, avgBlockDurationUSecs uint64, avgNetworkLatency uint64, stats *stats.Stats) *ethereum_mock.Node {
+func createMockEthNode(id int64, nrNodes int, avgBlockDurationUSecs time.Duration, avgNetworkLatency time.Duration, stats *stats.Stats) *ethereum_mock.Node {
 	mockEthNetwork := ethereum_mock.NewMockEthNetwork(avgBlockDurationUSecs, avgNetworkLatency, stats)
 	ethereumMockCfg := defaultMockEthNodeCfg(nrNodes, avgBlockDurationUSecs)
 	// create an in memory mock ethereum node responsible with notifying the layer 2 node about blocks
@@ -32,7 +32,7 @@ func createMockEthNode(id int64, nrNodes int, avgBlockDurationUSecs uint64, avgN
 	return &miner
 }
 
-func createInMemObscuroNode(id int64, genesis bool, avgGossipPeriod uint64, avgBlockDurationUSecs uint64, avgNetworkLatency uint64, stats *stats.Stats) *host.Node {
+func createInMemObscuroNode(id int64, genesis bool, avgGossipPeriod time.Duration, avgBlockDurationUSecs time.Duration, avgNetworkLatency time.Duration, stats *stats.Stats) *host.Node {
 	obscuroInMemNetwork := p2p2.NewMockP2P(avgBlockDurationUSecs, avgNetworkLatency)
 
 	obscuroNodeCfg := defaultObscuroNodeCfg(avgGossipPeriod)
@@ -46,7 +46,7 @@ func createInMemObscuroNode(id int64, genesis bool, avgGossipPeriod uint64, avgB
 	return &node
 }
 
-func createSocketObscuroNode(id int64, genesis bool, avgGossipPeriod uint64, stats *stats.Stats, p2pAddr string, peerAddrs []string, enclavePort uint64) *host.Node {
+func createSocketObscuroNode(id int64, genesis bool, avgGossipPeriod time.Duration, stats *stats.Stats, p2pAddr string, peerAddrs []string, enclavePort uint64) *host.Node {
 	nodeID := common.BigToAddress(big.NewInt(id))
 
 	// create an enclave client
@@ -61,11 +61,11 @@ func createSocketObscuroNode(id int64, genesis bool, avgGossipPeriod uint64, sta
 	return &node
 }
 
-func defaultObscuroNodeCfg(gossipPeriod uint64) host.AggregatorCfg {
+func defaultObscuroNodeCfg(gossipPeriod time.Duration) host.AggregatorCfg {
 	return host.AggregatorCfg{ClientRPCTimeoutSecs: host.ClientRPCTimeoutSecs, GossipRoundDuration: gossipPeriod}
 }
 
-func defaultMockEthNodeCfg(nrNodes int, avgBlockDuration uint64) ethereum_mock.MiningConfig {
+func defaultMockEthNodeCfg(nrNodes int, avgBlockDuration time.Duration) ethereum_mock.MiningConfig {
 	return ethereum_mock.MiningConfig{
 		PowTime: func() uint64 {
 			// This formula might feel counter-intuitive, but it is a good approximation for Proof of Work.
@@ -73,7 +73,7 @@ func defaultMockEthNodeCfg(nrNodes int, avgBlockDuration uint64) ethereum_mock.M
 			// Which means on average, every round, the winner (miner who gets the lowest nonce) will pick a number around "avgDuration"
 			// while everyone else will have higher values.
 			// Over a large number of rounds, the actual average block duration will be around the desired value, while the number of miners who get very close numbers will be limited.
-			return obscurocommon.RndBtw(avgBlockDuration/uint64(nrNodes), uint64(nrNodes)*avgBlockDuration)
+			return obscurocommon.RndBtw(uint64(avgBlockDuration.Nanoseconds()/int64(nrNodes)), uint64(int64(nrNodes)*avgBlockDuration.Nanoseconds()))
 		},
 	}
 }

--- a/integration/simulation/p2p/mock_l2_network.go
+++ b/integration/simulation/p2p/mock_l2_network.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"sync/atomic"
+	"time"
 
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
 
@@ -16,14 +17,14 @@ type MockP2P struct {
 	CurrentNode *host.Node
 	Nodes       []*host.Node
 
-	avgLatency       uint64
-	avgBlockDuration uint64
+	avgLatency       time.Duration
+	avgBlockDuration time.Duration
 
 	listenerInterrupt *int32
 }
 
 // NewMockP2P returns an instance of a configured L2 Network (no nodes)
-func NewMockP2P(avgBlockDuration uint64, avgLatency uint64) *MockP2P {
+func NewMockP2P(avgBlockDuration time.Duration, avgLatency time.Duration) *MockP2P {
 	i := int32(0)
 	return &MockP2P{
 		avgLatency:        avgLatency,
@@ -69,5 +70,5 @@ func (netw *MockP2P) BroadcastTx(tx nodecommon.EncryptedTx) {
 
 // delay returns an expected delay on the l2
 func (netw *MockP2P) delay() uint64 {
-	return obscurocommon.RndBtw(netw.avgLatency/10, 2*netw.avgLatency)
+	return obscurocommon.RndBtw(uint64(netw.avgLatency.Nanoseconds()/10), uint64(2*netw.avgLatency.Nanoseconds()))
 }

--- a/integration/simulation/params/params.go
+++ b/integration/simulation/params/params.go
@@ -8,9 +8,9 @@ type SimParams struct {
 	NumberOfWallets int
 
 	// A critical parameter of the simulation. The value should be as low as possible, as long as the test is still meaningful
-	AvgBlockDurationUSecs time.Duration
-	AvgNetworkLatency     time.Duration // artificial latency injected between sending and receiving messages on the mock network
-	AvgGossipPeriod       time.Duration // POBI protocol setting
+	AvgBlockDuration  time.Duration
+	AvgNetworkLatency time.Duration // artificial latency injected between sending and receiving messages on the mock network
+	AvgGossipPeriod   time.Duration // POBI protocol setting
 
 	SimulationTime time.Duration // how long the simulations should run for
 

--- a/integration/simulation/params/params.go
+++ b/integration/simulation/params/params.go
@@ -8,9 +8,9 @@ type SimParams struct {
 	NumberOfWallets int
 
 	// A critical parameter of the simulation. The value should be as low as possible, as long as the test is still meaningful
-	AvgBlockDurationUSecs uint64
-	AvgNetworkLatency     uint64 // artificial latency injected between sending and receiving messages on the mock network
-	AvgGossipPeriod       uint64 // POBI protocol setting
+	AvgBlockDurationUSecs time.Duration
+	AvgNetworkLatency     time.Duration // artificial latency injected between sending and receiving messages on the mock network
+	AvgGossipPeriod       time.Duration // POBI protocol setting
 
 	SimulationTime time.Duration // how long the simulations should run for
 

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -45,6 +45,8 @@ func (s *Simulation) Start() {
 	// Wait for the simulation time
 	time.Sleep(s.SimulationTime)
 
+	s.TxInjector.Stop()
+
 	fmt.Printf("Ran simulation for %f secs, configured to run for: %s ... \n", time.Since(timer).Seconds(), s.SimulationTime)
 	time.Sleep(time.Second)
 }

--- a/integration/simulation/simulation_docker_test.go
+++ b/integration/simulation/simulation_docker_test.go
@@ -41,14 +41,14 @@ func TestDockerNodesMonteCarloSimulation(t *testing.T) {
 	params := params.SimParams{
 		NumberOfNodes:             10,
 		NumberOfWallets:           5,
-		AvgBlockDurationUSecs:     uint64(250_000),
+		AvgBlockDuration:          uint64(250_000),
 		SimulationTime:            15 * time.Second,
 		L1EfficiencyThreshold:     0.2,
 		L2EfficiencyThreshold:     0.3,
 		L2ToL1EfficiencyThreshold: 0.5,
 	}
-	params.AvgNetworkLatency = params.AvgBlockDurationUSecs / 15
-	params.AvgGossipPeriod = params.AvgBlockDurationUSecs / 3
+	params.AvgNetworkLatency = params.AvgBlockDuration / 15
+	params.AvgGossipPeriod = params.AvgBlockDuration / 3
 
 	// We create a Docker client.
 	ctx := context.Background()

--- a/integration/simulation/simulation_docker_test.go
+++ b/integration/simulation/simulation_docker_test.go
@@ -41,7 +41,7 @@ func TestDockerNodesMonteCarloSimulation(t *testing.T) {
 	params := params.SimParams{
 		NumberOfNodes:             10,
 		NumberOfWallets:           5,
-		AvgBlockDuration:          uint64(250_000),
+		AvgBlockDuration:          250 * time.Microsecond,
 		SimulationTime:            15 * time.Second,
 		L1EfficiencyThreshold:     0.2,
 		L2EfficiencyThreshold:     0.3,

--- a/integration/simulation/simulation_in_mem_test.go
+++ b/integration/simulation/simulation_in_mem_test.go
@@ -11,7 +11,7 @@ import (
 
 // This test creates a network of in memory L1 and L2 nodes, then injects transactions, and finally checks the resulting output blockchain.
 // Running it long enough with various parameters will test many corner cases without having to explicitly write individual tests for them.
-// The unit of time is the "AvgBlockDurationUSecs" - which is the average time between L1 blocks, which are the carriers of rollups.
+// The unit of time is the "AvgBlockDuration" - which is the average time between L1 blocks, which are the carriers of rollups.
 // Everything else is reported to this value. This number has to be adjusted in conjunction with the number of nodes. If it's too low,
 // the CPU usage will be very high during the simulation which might result in inconclusive results.
 func TestInMemoryMonteCarloSimulation(t *testing.T) {
@@ -21,15 +21,15 @@ func TestInMemoryMonteCarloSimulation(t *testing.T) {
 	params := params.SimParams{
 		NumberOfNodes:             10,
 		NumberOfWallets:           5,
-		AvgBlockDurationUSecs:     40 * time.Microsecond,
+		AvgBlockDuration:          40 * time.Microsecond,
 		SimulationTime:            15 * time.Second,
 		L1EfficiencyThreshold:     0.2,
 		L2EfficiencyThreshold:     0.32,
 		L2ToL1EfficiencyThreshold: 0.34,
 	}
 
-	params.AvgNetworkLatency = params.AvgBlockDurationUSecs / 15
-	params.AvgGossipPeriod = params.AvgBlockDurationUSecs / 3
+	params.AvgNetworkLatency = params.AvgBlockDuration / 15
+	params.AvgGossipPeriod = params.AvgBlockDuration / 3
 
 	testSimulation(t, network.NewBasicNetworkOfInMemoryNodes(), params)
 }

--- a/integration/simulation/simulation_in_mem_test.go
+++ b/integration/simulation/simulation_in_mem_test.go
@@ -21,7 +21,7 @@ func TestInMemoryMonteCarloSimulation(t *testing.T) {
 	params := params.SimParams{
 		NumberOfNodes:             10,
 		NumberOfWallets:           5,
-		AvgBlockDurationUSecs:     uint64(40_000),
+		AvgBlockDurationUSecs:     40 * time.Microsecond,
 		SimulationTime:            15 * time.Second,
 		L1EfficiencyThreshold:     0.2,
 		L2EfficiencyThreshold:     0.32,

--- a/integration/simulation/simulation_socket_test.go
+++ b/integration/simulation/simulation_socket_test.go
@@ -19,14 +19,14 @@ func TestSocketNodesMonteCarloSimulation(t *testing.T) {
 	params := params.SimParams{
 		NumberOfNodes:             10,
 		NumberOfWallets:           5,
-		AvgBlockDurationUSecs:     250 * time.Microsecond,
+		AvgBlockDuration:          250 * time.Microsecond,
 		SimulationTime:            15 * time.Second,
 		L1EfficiencyThreshold:     0.2,
 		L2EfficiencyThreshold:     0.3,
 		L2ToL1EfficiencyThreshold: 0.4,
 	}
-	params.AvgNetworkLatency = params.AvgBlockDurationUSecs / 15
-	params.AvgGossipPeriod = params.AvgBlockDurationUSecs / 3
+	params.AvgNetworkLatency = params.AvgBlockDuration / 15
+	params.AvgGossipPeriod = params.AvgBlockDuration / 3
 
 	testSimulation(t, network.NewBasicNetworkOfSocketNodes(), params)
 }

--- a/integration/simulation/simulation_socket_test.go
+++ b/integration/simulation/simulation_socket_test.go
@@ -19,7 +19,7 @@ func TestSocketNodesMonteCarloSimulation(t *testing.T) {
 	params := params.SimParams{
 		NumberOfNodes:             10,
 		NumberOfWallets:           5,
-		AvgBlockDurationUSecs:     uint64(250_000),
+		AvgBlockDurationUSecs:     250 * time.Microsecond,
 		SimulationTime:            15 * time.Second,
 		L1EfficiencyThreshold:     0.2,
 		L2EfficiencyThreshold:     0.3,

--- a/integration/simulation/simulation_tester.go
+++ b/integration/simulation/simulation_tester.go
@@ -22,13 +22,13 @@ func testSimulation(t *testing.T, netw network.Network, params params.SimParams)
 
 	ethClients, obscuroNodes, p2pAddrs := netw.Create(params, stats)
 
-	txInjector := NewTransactionInjector(params.NumberOfWallets, params.AvgBlockDurationUSecs, stats, ethClients, obscuroNodes)
+	txInjector := NewTransactionInjector(params.NumberOfWallets, uint64(params.AvgBlockDurationUSecs), stats, ethClients, obscuroNodes)
 
 	simulation := Simulation{
 		EthClients:       ethClients,
 		ObscuroNodes:     obscuroNodes,
 		ObscuroP2PAddrs:  p2pAddrs,
-		AvgBlockDuration: params.AvgBlockDurationUSecs,
+		AvgBlockDuration: uint64(params.AvgBlockDurationUSecs),
 		TxInjector:       txInjector,
 		SimulationTime:   params.SimulationTime,
 		Stats:            stats,

--- a/integration/simulation/simulation_tester.go
+++ b/integration/simulation/simulation_tester.go
@@ -22,7 +22,7 @@ func testSimulation(t *testing.T, netw network.Network, params params.SimParams)
 
 	ethClients, obscuroNodes, p2pAddrs := netw.Create(params, stats)
 
-	txInjector := NewTransactionInjector(params.NumberOfWallets, params.AvgBlockDurationUSecs, stats, params.SimulationTime, ethClients, obscuroNodes)
+	txInjector := NewTransactionInjector(params.NumberOfWallets, params.AvgBlockDurationUSecs, stats, ethClients, obscuroNodes)
 
 	simulation := Simulation{
 		EthClients:       ethClients,

--- a/integration/simulation/simulation_tester.go
+++ b/integration/simulation/simulation_tester.go
@@ -22,13 +22,13 @@ func testSimulation(t *testing.T, netw network.Network, params params.SimParams)
 
 	ethClients, obscuroNodes, p2pAddrs := netw.Create(params, stats)
 
-	txInjector := NewTransactionInjector(params.NumberOfWallets, uint64(params.AvgBlockDurationUSecs), stats, ethClients, obscuroNodes)
+	txInjector := NewTransactionInjector(params.NumberOfWallets, uint64(params.AvgBlockDuration), stats, ethClients, obscuroNodes)
 
 	simulation := Simulation{
 		EthClients:       ethClients,
 		ObscuroNodes:     obscuroNodes,
 		ObscuroP2PAddrs:  p2pAddrs,
-		AvgBlockDuration: uint64(params.AvgBlockDurationUSecs),
+		AvgBlockDuration: uint64(params.AvgBlockDuration),
 		TxInjector:       txInjector,
 		SimulationTime:   params.SimulationTime,
 		Stats:            stats,

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -117,7 +117,7 @@ func (m *TransactionInjector) Start() {
 
 func (m *TransactionInjector) Stop() {
 	atomic.StoreInt32(m.interruptRun, 1)
-	for _ = range m.fullyStoppedChan {
+	for range m.fullyStoppedChan {
 		log.Log("TransactionInjector stopped successfully")
 		return
 	}

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -117,12 +117,9 @@ func (m *TransactionInjector) Start() {
 
 func (m *TransactionInjector) Stop() {
 	atomic.StoreInt32(m.interruptRun, 1)
-	for {
-		select {
-		case <-m.fullyStoppedChan:
-			log.Log("TransactionInjector stopped successfully")
-			return
-		}
+	for _ = range m.fullyStoppedChan {
+		log.Log("TransactionInjector stopped successfully")
+		return
 	}
 }
 

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/obscuronet/obscuro-playground/go/log"
+
 	"github.com/obscuronet/obscuro-playground/go/ethclient"
 
 	stats2 "github.com/obscuronet/obscuro-playground/integration/simulation/stats"
@@ -26,7 +28,6 @@ import (
 type TransactionInjector struct {
 	// settings
 	avgBlockDuration uint64
-	injectionTimeUs  time.Duration
 	stats            *stats2.Stats
 	wallets          []wallet_mock.Wallet
 
@@ -38,6 +39,9 @@ type TransactionInjector struct {
 
 	l2TransactionsLock sync.RWMutex
 	l2Transactions     enclave.L2Txs
+
+	running bool
+	stopped bool
 }
 
 // NewTransactionInjector returns a transaction manager with a given number of wallets
@@ -46,7 +50,6 @@ func NewTransactionInjector(
 	numberWallets int,
 	avgBlockDuration uint64,
 	stats *stats2.Stats,
-	injectionTime time.Duration,
 	l1Nodes []ethclient.Client,
 	l2Nodes []*host.Node,
 ) *TransactionInjector {
@@ -60,7 +63,6 @@ func NewTransactionInjector(
 		wallets:          wallets,
 		avgBlockDuration: avgBlockDuration,
 		stats:            stats,
-		injectionTimeUs:  injectionTime,
 		l1Nodes:          l1Nodes,
 		l2Nodes:          l2Nodes,
 	}
@@ -107,6 +109,18 @@ func (m *TransactionInjector) Start() {
 	})
 
 	_ = wg.Wait() // future proofing to return errors
+	m.stopped = true
+}
+
+func (m *TransactionInjector) Stop() {
+	m.running = false
+	for {
+		if m.stopped {
+			return
+		}
+		time.Sleep(time.Second)
+		log.Log("TransactionInjector stopped successfully")
+	}
 }
 
 // trackL1Tx adds an L1Tx to the internal list
@@ -153,12 +167,7 @@ func (m *TransactionInjector) GetL2WithdrawalRequests() []nodecommon.Withdrawal 
 
 // issueRandomTransfers creates and issues a number of L2 transfer transactions proportional to the simulation time, such that they can be processed
 func (m *TransactionInjector) issueRandomTransfers() {
-	n := uint64(m.injectionTimeUs.Microseconds()) / m.avgBlockDuration
-	i := uint64(0)
-	for {
-		if i == n {
-			break
-		}
+	for ; m.running; time.Sleep(obscurocommon.Duration(obscurocommon.RndBtw(m.avgBlockDuration/4, m.avgBlockDuration))) {
 		fromWallet := rndWallet(m.wallets)
 		to := rndWallet(m.wallets).Address
 		for fromWallet.Address == to {
@@ -170,20 +179,13 @@ func (m *TransactionInjector) issueRandomTransfers() {
 		m.stats.Transfer()
 		m.rndL2Node().P2p.BroadcastTx(encryptedTx)
 		go m.trackL2Tx(*signedTx)
-		time.Sleep(obscurocommon.Duration(obscurocommon.RndBtw(m.avgBlockDuration/4, m.avgBlockDuration)))
-		i++
 	}
 }
 
 // issueRandomDeposits creates and issues a number of transactions proportional to the simulation time, such that they can be processed
 // Generates L1 common.DepositTx transactions
 func (m *TransactionInjector) issueRandomDeposits() {
-	n := uint64(m.injectionTimeUs.Microseconds()) / (m.avgBlockDuration * 3)
-	i := uint64(0)
-	for {
-		if i == n {
-			break
-		}
+	for ; m.running; time.Sleep(obscurocommon.Duration(obscurocommon.RndBtw(m.avgBlockDuration, m.avgBlockDuration*2))) {
 		v := obscurocommon.RndBtw(1, 100)
 		txData := obscurocommon.L1TxData{
 			TxType: obscurocommon.DepositTx,
@@ -195,20 +197,13 @@ func (m *TransactionInjector) issueRandomDeposits() {
 		m.rndL1Node().IssueTx(t)
 		m.stats.Deposit(v)
 		go m.trackL1Tx(txData)
-		time.Sleep(obscurocommon.Duration(obscurocommon.RndBtw(m.avgBlockDuration, m.avgBlockDuration*2)))
-		i++
 	}
 }
 
 // issueRandomWithdrawals creates and issues a number of transactions proportional to the simulation time, such that they can be processed
 // Generates L2 enclave2.WithdrawalTx transactions
 func (m *TransactionInjector) issueRandomWithdrawals() {
-	n := uint64(m.injectionTimeUs.Microseconds()) / (m.avgBlockDuration * 3)
-	i := uint64(0)
-	for {
-		if i == n {
-			break
-		}
+	for ; m.running; time.Sleep(obscurocommon.Duration(obscurocommon.RndBtw(m.avgBlockDuration, m.avgBlockDuration*2))) {
 		v := obscurocommon.RndBtw(1, 100)
 		wallet := rndWallet(m.wallets)
 		tx := wallet_mock.NewL2Withdrawal(wallet.Address, v)
@@ -217,27 +212,18 @@ func (m *TransactionInjector) issueRandomWithdrawals() {
 		m.rndL2Node().P2p.BroadcastTx(encryptedTx)
 		m.stats.Withdrawal(v)
 		go m.trackL2Tx(*signedTx)
-		time.Sleep(obscurocommon.Duration(obscurocommon.RndBtw(m.avgBlockDuration, m.avgBlockDuration*2)))
-		i++
 	}
 }
 
 // issueInvalidWithdrawals creates and issues a number of invalidly-signed L2 withdrawal transactions proportional to the simulation time.
 // These transactions should be rejected by the nodes, and thus we expect them not to show up in the simulation withdrawal checks.
 func (m *TransactionInjector) issueInvalidWithdrawals() {
-	n := uint64(m.injectionTimeUs.Microseconds()) / (m.avgBlockDuration * 3)
-	i := uint64(0)
-	for {
-		if i == n {
-			break
-		}
+	for ; m.running; time.Sleep(obscurocommon.Duration(obscurocommon.RndBtw(m.avgBlockDuration/4, m.avgBlockDuration))) {
 		fromWallet := rndWallet(m.wallets)
 		tx := wallet_mock.NewL2Withdrawal(fromWallet.Address, obscurocommon.RndBtw(1, 100))
 		signedTx := createInvalidSignature(tx, &fromWallet)
 		encryptedTx := enclave.EncryptTx(signedTx)
 		m.rndL2Node().P2p.BroadcastTx(encryptedTx)
-		time.Sleep(obscurocommon.Duration(obscurocommon.RndBtw(m.avgBlockDuration/4, m.avgBlockDuration)))
-		i++
 	}
 }
 

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -29,7 +29,7 @@ func checkNetworkValidity(t *testing.T, s *Simulation) {
 // - noReorgs
 func checkEthereumBlockchainValidity(t *testing.T, s *Simulation) uint64 {
 	// Sanity check number for a minimum height
-	minHeight := uint64(float64(s.Params.SimulationTime.Microseconds()) / (2 * float64(s.Params.AvgBlockDurationUSecs)))
+	minHeight := uint64(float64(s.Params.SimulationTime.Microseconds()) / (2 * float64(s.Params.AvgBlockDuration)))
 
 	heights := make([]uint64, len(s.EthClients))
 	for i, node := range s.EthClients {
@@ -53,7 +53,7 @@ func checkEthereumBlockchainValidity(t *testing.T, s *Simulation) uint64 {
 // - check withdrawals/deposits
 func checkObscuroBlockchainValidity(t *testing.T, s *Simulation, maxL1Height uint64) {
 	// Sanity check number for a minimum height
-	minHeight := uint64(float64(s.Params.SimulationTime.Microseconds()) / (2 * float64(s.Params.AvgBlockDurationUSecs)))
+	minHeight := uint64(float64(s.Params.SimulationTime.Microseconds()) / (2 * float64(s.Params.AvgBlockDuration)))
 
 	heights := make([]uint64, len(s.ObscuroNodes))
 	for i, node := range s.ObscuroNodes {


### PR DESCRIPTION
Changes the Tx injector from a time iterative execution to a start-stop best effort execution.

The change is a necessity for https://github.com/obscuronet/obscuro-playground/pull/67 as using geth introduces a lag that the tx injector wasn't handling correctly making it run longer than the simulation.

The tx injector is calculating the N transactions that will be issued and it waits a fraction of time between issuing them.
Because it's an in-memory process, the N transactions are all issued before the simulation stops / the validation runs.
Geth adds delay to each transaction. So the N transactions will never be issued fast enough and this scrambles the validation.

There might be better approaches than start/stop, I just thought this was the easiest right now :)

Also changed a few `uint64` to time.duration.
 


