### PR TITLE
isolate the db logic in own package

### DIFF
--- a/go/obscuronode/enclave/core/crypto.go
+++ b/go/obscuronode/enclave/core/crypto.go
@@ -1,11 +1,11 @@
-package enclave
+package core
 
 import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 )
 
-func decryptTransactions(txs nodecommon.EncryptedTransactions) L2Txs {
+func DecryptTransactions(txs nodecommon.EncryptedTransactions) L2Txs {
 	t := make([]nodecommon.L2Tx, 0)
 	for _, tx := range txs {
 		t = append(t, DecryptTx(tx))
@@ -30,17 +30,12 @@ func EncryptTx(tx *nodecommon.L2Tx) nodecommon.EncryptedTx {
 	return bytes
 }
 
-func encryptTransactions(transactions L2Txs) nodecommon.EncryptedTransactions {
-	result := make([]nodecommon.EncryptedTx, 0)
-	for i := range transactions {
-		result = append(result, EncryptTx(&transactions[i]))
-	}
-	return result
-}
+//func DecryptRollup(rollup *nodecommon.Rollup) *Rollup {
+//	return &Rollup{
+//		Header:       rollup.Header,
+//		Transactions: DecryptTransactions(rollup.Transactions),
+//	}
+//}
 
-func DecryptRollup(rollup *nodecommon.Rollup) *Rollup {
-	return &Rollup{
-		Header:       rollup.Header,
-		Transactions: decryptTransactions(rollup.Transactions),
-	}
-}
+// todo - this should become an elaborate data structure
+type SharedEnclaveSecret []byte

--- a/go/obscuronode/enclave/core/crypto.go
+++ b/go/obscuronode/enclave/core/crypto.go
@@ -5,6 +5,9 @@ import (
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 )
 
+// todo - this should become an elaborate data structure
+type SharedEnclaveSecret []byte
+
 func DecryptTransactions(txs nodecommon.EncryptedTransactions) L2Txs {
 	t := make([]nodecommon.L2Tx, 0)
 	for _, tx := range txs {
@@ -29,13 +32,3 @@ func EncryptTx(tx *nodecommon.L2Tx) nodecommon.EncryptedTx {
 	}
 	return bytes
 }
-
-//func DecryptRollup(rollup *nodecommon.Rollup) *Rollup {
-//	return &Rollup{
-//		Header:       rollup.Header,
-//		Transactions: DecryptTransactions(rollup.Transactions),
-//	}
-//}
-
-// todo - this should become an elaborate data structure
-type SharedEnclaveSecret []byte

--- a/go/obscuronode/enclave/core/l2tx.go
+++ b/go/obscuronode/enclave/core/l2tx.go
@@ -1,4 +1,4 @@
-package enclave
+package core
 
 import (
 	"github.com/ethereum/go-ethereum/rlp"

--- a/go/obscuronode/enclave/core/rollup.go
+++ b/go/obscuronode/enclave/core/rollup.go
@@ -1,10 +1,9 @@
-package enclave
+package core
 
 import (
 	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 )
@@ -31,7 +30,7 @@ func (r *Rollup) Hash() obscurocommon.L2RootHash {
 	return v
 }
 
-func newHeader(parent *Rollup, height uint64, a common.Address) *nodecommon.Header {
+func NewHeader(parent *Rollup, height uint64, a common.Address) *nodecommon.Header {
 	parentHash := obscurocommon.GenesisHash
 	if parent != nil {
 		parentHash = parent.Hash()
@@ -81,27 +80,17 @@ func NewRollup(blkHash common.Hash, parent *Rollup, height uint64, a common.Addr
 	return r
 }
 
-// ProofHeight - return the height of the L1 proof, or GenesisHeight - if the block is not known
-// todo - find a better way. This is a workaround to handle rollups created with proofs that haven't propagated yet
-func (r *Rollup) ProofHeight(l1BlockResolver BlockResolver) int64 {
-	v, f := l1BlockResolver.FetchBlock(r.Header.L1Proof)
-	if !f {
-		return -1
-	}
-	return int64(l1BlockResolver.HeightBlock(v))
-}
-
 func (r *Rollup) ToExtRollup() nodecommon.ExtRollup {
 	return nodecommon.ExtRollup{
 		Header: r.Header,
-		Txs:    encryptTransactions(r.Transactions),
+		Txs:    EncryptTransactions(r.Transactions),
 	}
 }
 
-func (r *Rollup) Proof(l1BlockResolver BlockResolver) *types.Block {
-	v, f := l1BlockResolver.FetchBlock(r.Header.L1Proof)
-	if !f {
-		panic("Could not find proof for this rollup")
+func EncryptTransactions(transactions L2Txs) nodecommon.EncryptedTransactions {
+	result := make([]nodecommon.EncryptedTx, 0)
+	for i := range transactions {
+		result = append(result, EncryptTx(&transactions[i]))
 	}
-	return v
+	return result
 }

--- a/go/obscuronode/enclave/core/rollup_test.go
+++ b/go/obscuronode/enclave/core/rollup_test.go
@@ -1,4 +1,4 @@
-package enclave
+package core
 
 import (
 	"math/big"
@@ -13,7 +13,7 @@ import (
 )
 
 func TestSerialiseL2Tx(t *testing.T) {
-	tx := createL2Tx()
+	tx := CreateL2Tx()
 	bytes, err := rlp.EncodeToBytes(tx)
 	if err != nil {
 		panic(err)
@@ -29,12 +29,12 @@ func TestSerialiseL2Tx(t *testing.T) {
 }
 
 func TestSerialiseRollup(t *testing.T) {
-	tx := createL2Tx()
+	tx := CreateL2Tx()
 	height := atomic.Value{}
 	height.Store(1)
 	rollup := nodecommon.Rollup{
 		Header:       NewRollup(obscurocommon.GenesisBlock.Hash(), nil, obscurocommon.L2GenesisHeight, common.HexToAddress("0x0"), []nodecommon.L2Tx{}, []nodecommon.Withdrawal{}, obscurocommon.GenerateNonce(), common.BigToHash(big.NewInt(0))).Header,
-		Transactions: encryptTransactions(L2Txs{*tx}),
+		Transactions: EncryptTransactions(L2Txs{*tx}),
 	}
 	_, read, err := rlp.EncodeToReader(&rollup)
 	if err != nil {

--- a/go/obscuronode/enclave/core/test_utils.go
+++ b/go/obscuronode/enclave/core/test_utils.go
@@ -1,4 +1,4 @@
-package enclave
+package core
 
 import (
 	"crypto/rand"
@@ -13,12 +13,12 @@ import (
 )
 
 // Creates a dummy L2Tx for testing
-func createL2Tx() *nodecommon.L2Tx {
-	return types.NewTx(createL2TxData())
+func CreateL2Tx() *nodecommon.L2Tx {
+	return types.NewTx(CreateL2TxData())
 }
 
 // Creates a dummy types.LegacyTx for testing
-func createL2TxData() *types.LegacyTx {
+func CreateL2TxData() *types.LegacyTx {
 	txData := L2TxData{TransferTx, common.Address{}, common.Address{}, 100}
 	nonce, _ := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
 	encodedTxData, _ := rlp.EncodeToBytes(txData)

--- a/go/obscuronode/enclave/db/db.go
+++ b/go/obscuronode/enclave/db/db.go
@@ -14,17 +14,13 @@ import (
 	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 )
 
-// TODO - Further generify this interface's methods
-// TODO - Put this in a separate package to enclave
-
-// DB lives purely in the encrypted memory space of an enclave.
-// Unlike Storage, methods in this class should have minimal logic, to map them more easily to our chosen datastore.
-
 type blockAndHeight struct {
 	b      *types.Block
 	height uint64
 }
 
+// DB lives purely in the encrypted memory space of an enclave.
+// Unlike Storage, methods in this class should have minimal logic, to map them more easily to our chosen datastore.
 type inMemoryDB struct {
 	rollupGenesisHash common.Hash // TODO add lock protection, not needed atm
 

--- a/go/obscuronode/enclave/db/db.go
+++ b/go/obscuronode/enclave/db/db.go
@@ -41,7 +41,7 @@ type inMemoryDB struct {
 	sharedEnclaveSecret core.SharedEnclaveSecret
 }
 
-func NewInMemoryDB() *inMemoryDB {
+func newInMemoryDB() *inMemoryDB {
 	return &inMemoryDB{
 		statePerBlock:     make(map[obscurocommon.L1RootHash]*BlockState),
 		stateMutex:        sync.RWMutex{},

--- a/go/obscuronode/enclave/db/storage.go
+++ b/go/obscuronode/enclave/db/storage.go
@@ -107,7 +107,7 @@ func (s *storageImpl) FetchGenesisRollup() *core.Rollup {
 }
 
 func NewStorage() Storage {
-	db := NewInMemoryDB()
+	db := newInMemoryDB()
 	return &storageImpl{db: db}
 }
 

--- a/go/obscuronode/enclave/db/types.go
+++ b/go/obscuronode/enclave/db/types.go
@@ -1,0 +1,58 @@
+package db
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/obscuronet/obscuro-playground/go/hashing"
+	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
+)
+
+// State - this is a placeholder for the real Trie based state
+//- people send transactions to an ObsERC20 that was a withdraw(amount, from, destination) method
+//In the EVM, there will be a smart contract that does the following:
+//- the tokens are deducted from the "from" address , and burned
+//- add to the "Withdrawals" transactions - this info will be taken from the state
+//Post processing, outside the evm:
+//- generate withdrawal instructions (amount, destination), based on which withdrawal transaction were executed successfully
+type State struct {
+	Balances    map[common.Address]uint64
+	Withdrawals []obscurocommon.TxHash
+}
+
+// BlockState - Represents the state after an L1 Block was processed.
+type BlockState struct {
+	Block          *types.Block
+	Head           *core.Rollup
+	State          *State
+	FoundNewRollup bool
+}
+
+func CopyState(state *State) *State {
+	s := EmptyState()
+	if state == nil {
+		return s
+	}
+	for address, balance := range state.Balances {
+		s.Balances[address] = balance
+	}
+	s.Withdrawals = append(s.Withdrawals, state.Withdrawals...)
+	return s
+}
+
+func Serialize(state *State) nodecommon.StateRoot {
+	hash, err := hashing.RLPHash(fmt.Sprintf("%v", state))
+	if err != nil {
+		panic(err)
+	}
+	return hash
+}
+
+func EmptyState() *State {
+	return &State{
+		Balances: map[common.Address]uint64{},
+	}
+}

--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"math/big"
 
+	obscurocore "github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/db"
+
 	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
 
 	"github.com/ethereum/go-ethereum/core"
@@ -19,9 +22,6 @@ import (
 
 const ChainID = 777 // The unique ID for the Obscuro chain. Required for Geth signing.
 
-// todo - this should become an elaborate data structure
-type SharedEnclaveSecret []byte
-
 type StatsCollector interface {
 	// Register when a node has to discard the speculative work built on top of the winner of the gossip round.
 	L2Recalc(id common.Address)
@@ -31,13 +31,13 @@ type StatsCollector interface {
 type enclaveImpl struct {
 	node           common.Address
 	mining         bool
-	storage        Storage
-	blockResolver  BlockResolver
+	storage        db.Storage
+	blockResolver  db.BlockResolver
 	statsCollector StatsCollector
 	l1Blockchain   *core.BlockChain
 
 	txCh                 chan nodecommon.L2Tx
-	roundWinnerCh        chan *Rollup
+	roundWinnerCh        chan *obscurocore.Rollup
 	exitCh               chan bool
 	speculativeWorkInCh  chan bool
 	speculativeWorkOutCh chan speculativeWork
@@ -62,9 +62,9 @@ func (e *enclaveImpl) start(block types.Block) {
 	// determine whether the block where the speculative execution will start already contains Obscuro state
 	blockState, f := e.storage.FetchBlockState(block.Hash())
 	if f {
-		env.headRollup = blockState.head
+		env.headRollup = blockState.Head
 		if env.headRollup != nil {
-			env.state = copyState(e.storage.FetchRollupState(env.headRollup.Hash()))
+			env.state = db.CopyState(e.storage.FetchRollupState(env.headRollup.Hash()))
 		}
 	}
 
@@ -72,9 +72,9 @@ func (e *enclaveImpl) start(block types.Block) {
 		select {
 		// A new winner was found after gossiping. Start speculatively executing incoming transactions to already have a rollup ready when the next round starts.
 		case winnerRollup := <-e.roundWinnerCh:
-			env.header = newHeader(winnerRollup, winnerRollup.Header.Height+1, e.node)
+			env.header = obscurocore.NewHeader(winnerRollup, winnerRollup.Header.Height+1, e.node)
 			env.headRollup = winnerRollup
-			env.state = copyState(e.storage.FetchRollupState(winnerRollup.Hash()))
+			env.state = db.CopyState(e.storage.FetchRollupState(winnerRollup.Hash()))
 
 			// determine the transactions that were not yet included
 			env.processedTxs = currentTxs(winnerRollup, e.storage.FetchMempoolTxs(), e.storage)
@@ -100,7 +100,7 @@ func (e *enclaveImpl) start(block types.Block) {
 			} else {
 				b := make([]nodecommon.L2Tx, 0, len(env.processedTxs))
 				b = append(b, env.processedTxs...)
-				state := copyState(env.state)
+				state := db.CopyState(env.state)
 				e.speculativeWorkOutCh <- speculativeWork{
 					found: true,
 					r:     env.headRollup,
@@ -117,7 +117,7 @@ func (e *enclaveImpl) start(block types.Block) {
 }
 
 func (e *enclaveImpl) ProduceGenesis(blkHash common.Hash) nodecommon.BlockSubmissionResponse {
-	rolGenesis := NewRollup(blkHash, nil, obscurocommon.L2GenesisHeight, common.HexToAddress("0x0"), []nodecommon.L2Tx{}, []nodecommon.Withdrawal{}, obscurocommon.GenerateNonce(), common.BigToHash(big.NewInt(0)))
+	rolGenesis := obscurocore.NewRollup(blkHash, nil, obscurocommon.L2GenesisHeight, common.HexToAddress("0x0"), []nodecommon.L2Tx{}, []nodecommon.Withdrawal{}, obscurocommon.GenerateNonce(), common.BigToHash(big.NewInt(0)))
 	return nodecommon.BlockSubmissionResponse{
 		L2Hash:         rolGenesis.Header.Hash(),
 		L1Hash:         blkHash,
@@ -148,8 +148,8 @@ func (e *enclaveImpl) IngestBlocks(blocks []*types.Block) []nodecommon.BlockSubm
 			result[i] = e.noBlockStateBlockSubmissionResponse(block)
 		} else {
 			var rollup nodecommon.ExtRollup
-			if bs.foundNewRollup {
-				rollup = bs.head.ToExtRollup()
+			if bs.FoundNewRollup {
+				rollup = bs.Head.ToExtRollup()
 			}
 			result[i] = e.blockStateBlockSubmissionResponse(bs, rollup)
 		}
@@ -190,7 +190,7 @@ func (e *enclaveImpl) SubmitBlock(block types.Block) nodecommon.BlockSubmissionR
 	}
 
 	// todo - A verifier node will not produce rollups, we can check the e.mining to get the node behaviour
-	e.storage.RemoveMempoolTxs(historicTxs(blockState.head, e.storage))
+	e.storage.RemoveMempoolTxs(historicTxs(blockState.Head, e.storage))
 	r := e.produceRollup(&block, blockState)
 	// todo - should store proposal rollups in a different storage as they are ephemeral (round based)
 	e.storage.StoreRollup(r)
@@ -201,9 +201,9 @@ func (e *enclaveImpl) SubmitBlock(block types.Block) nodecommon.BlockSubmissionR
 }
 
 func (e *enclaveImpl) SubmitRollup(rollup nodecommon.ExtRollup) {
-	r := Rollup{
+	r := obscurocore.Rollup{
 		Header:       rollup.Header,
-		Transactions: decryptTransactions(rollup.Txs),
+		Transactions: obscurocore.DecryptTransactions(rollup.Txs),
 	}
 
 	// only store if the parent exists
@@ -216,7 +216,7 @@ func (e *enclaveImpl) SubmitRollup(rollup nodecommon.ExtRollup) {
 }
 
 func (e *enclaveImpl) SubmitTx(tx nodecommon.EncryptedTx) error {
-	decryptedTx := DecryptTx(tx)
+	decryptedTx := obscurocore.DecryptTx(tx)
 	err := verifySignature(&decryptedTx)
 	if err != nil {
 		return err
@@ -241,7 +241,7 @@ func (e *enclaveImpl) RoundWinner(parent obscurocommon.L2RootHash) (nodecommon.E
 
 	rollupsReceivedFromPeers := e.storage.FetchRollups(head.Header.Height + 1)
 	// filter out rollups with a different Parent
-	var usefulRollups []*Rollup
+	var usefulRollups []*obscurocore.Rollup
 	for _, rol := range rollupsReceivedFromPeers {
 		p := e.storage.ParentRollup(rol)
 		if p.Hash() == head.Hash() {
@@ -258,7 +258,7 @@ func (e *enclaveImpl) RoundWinner(parent obscurocommon.L2RootHash) (nodecommon.E
 
 	// we are the winner
 	if winnerRollup.Header.Agg == e.node {
-		v := winnerRollup.Proof(e.blockResolver)
+		v := e.blockResolver.Proof(winnerRollup)
 		w := e.storage.ParentRollup(winnerRollup)
 		log.Log(fmt.Sprintf(">   Agg%d: publish rollup=r_%d(%d)[r_%d]{proof=b_%d}. Num Txs: %d. Txs: %v.  State=%v. ",
 			obscurocommon.ShortAddress(e.node),
@@ -274,16 +274,16 @@ func (e *enclaveImpl) RoundWinner(parent obscurocommon.L2RootHash) (nodecommon.E
 	return nodecommon.ExtRollup{}, false, nil
 }
 
-func (e *enclaveImpl) notifySpeculative(winnerRollup *Rollup) {
+func (e *enclaveImpl) notifySpeculative(winnerRollup *obscurocore.Rollup) {
 	e.roundWinnerCh <- winnerRollup
 }
 
 func (e *enclaveImpl) Balance(address common.Address) uint64 {
 	// todo user encryption
-	return e.storage.FetchHeadState().state.balances[address]
+	return e.storage.FetchHeadState().State.Balances[address]
 }
 
-func (e *enclaveImpl) produceRollup(b *types.Block, bs *blockState) *Rollup {
+func (e *enclaveImpl) produceRollup(b *types.Block, bs *db.BlockState) *obscurocore.Rollup {
 	// retrieve the speculatively calculated State based on the previous winner and the incoming transactions
 	e.speculativeWorkInCh <- true
 	speculativeRollup := <-e.speculativeWorkOutCh
@@ -293,43 +293,43 @@ func (e *enclaveImpl) produceRollup(b *types.Block, bs *blockState) *Rollup {
 	newRollupHeader := speculativeRollup.h
 
 	// the speculative execution has been processing on top of the wrong parent - due to failure in gossip or publishing to L1
-	if !speculativeRollup.found || (speculativeRollup.r.Hash() != bs.head.Hash()) {
+	if !speculativeRollup.found || (speculativeRollup.r.Hash() != bs.Head.Hash()) {
 		if speculativeRollup.r != nil {
 			log.Log(fmt.Sprintf(">   Agg%d: Recalculate. speculative=r_%d(%d), published=r_%d(%d)",
 				obscurocommon.ShortAddress(e.node),
 				obscurocommon.ShortHash(speculativeRollup.r.Hash()),
 				speculativeRollup.r.Header.Height,
-				obscurocommon.ShortHash(bs.head.Hash()),
-				bs.head.Header.Height),
+				obscurocommon.ShortHash(bs.Head.Hash()),
+				bs.Head.Header.Height),
 			)
 			if e.statsCollector != nil {
 				e.statsCollector.L2Recalc(e.node)
 			}
 		}
 
-		newRollupHeader = newHeader(bs.head, bs.head.Header.Height+1, e.node)
+		newRollupHeader = obscurocore.NewHeader(bs.Head, bs.Head.Header.Height+1, e.node)
 		// determine transactions to include in new rollup and process them
-		newRollupTxs = currentTxs(bs.head, e.storage.FetchMempoolTxs(), e.storage)
-		newRollupState = executeTransactions(newRollupTxs, bs.state, newRollupHeader)
+		newRollupTxs = currentTxs(bs.Head, e.storage.FetchMempoolTxs(), e.storage)
+		newRollupState = executeTransactions(newRollupTxs, bs.State, newRollupHeader)
 	}
 
 	// always process deposits last
 	// process deposits from the proof of the parent to the current block (which is the proof of the new rollup)
-	proof := bs.head.Proof(e.blockResolver)
+	proof := e.blockResolver.Proof(bs.Head)
 	depositTxs := processDeposits(proof, b, e.blockResolver, e.txHandler)
 	newRollupState = executeTransactions(depositTxs, newRollupState, newRollupHeader)
 
 	// Postprocessing - withdrawals
-	withdrawals := rollupPostProcessingWithdrawals(bs.head, newRollupState)
+	withdrawals := rollupPostProcessingWithdrawals(bs.Head, newRollupState)
 
 	// Create a new rollup based on the proof of inclusion of the previous, including all new transactions
-	r := NewRollupFromHeader(newRollupHeader, b.Hash(), newRollupTxs, withdrawals, obscurocommon.GenerateNonce(), serialize(newRollupState))
+	r := obscurocore.NewRollupFromHeader(newRollupHeader, b.Hash(), newRollupTxs, withdrawals, obscurocommon.GenerateNonce(), db.Serialize(newRollupState))
 	return &r
 }
 
 func (e *enclaveImpl) GetTransaction(txHash common.Hash) *nodecommon.L2Tx {
 	// todo add some sort of cache
-	rollup := e.storage.FetchHeadState().head
+	rollup := e.storage.FetchHeadState().Head
 
 	var found bool
 	for {
@@ -411,45 +411,45 @@ func (e *enclaveImpl) noBlockStateBlockSubmissionResponse(block *types.Block) no
 	}
 }
 
-func (e *enclaveImpl) blockStateBlockSubmissionResponse(bs *blockState, rollup nodecommon.ExtRollup) nodecommon.BlockSubmissionResponse {
+func (e *enclaveImpl) blockStateBlockSubmissionResponse(bs *db.BlockState, rollup nodecommon.ExtRollup) nodecommon.BlockSubmissionResponse {
 	return nodecommon.BlockSubmissionResponse{
-		L1Hash:            bs.block.Hash(),
-		L1Height:          e.blockResolver.HeightBlock(bs.block),
-		L1Parent:          bs.block.ParentHash(),
-		L2Hash:            bs.head.Hash(),
-		L2Height:          bs.head.Header.Height,
-		L2Parent:          bs.head.Header.ParentHash,
-		Withdrawals:       bs.head.Header.Withdrawals,
+		L1Hash:            bs.Block.Hash(),
+		L1Height:          e.blockResolver.HeightBlock(bs.Block),
+		L1Parent:          bs.Block.ParentHash(),
+		L2Hash:            bs.Head.Hash(),
+		L2Height:          bs.Head.Header.Height,
+		L2Parent:          bs.Head.Header.ParentHash,
+		Withdrawals:       bs.Head.Header.Withdrawals,
 		ProducedRollup:    rollup,
 		IngestedBlock:     true,
-		IngestedNewRollup: bs.foundNewRollup,
+		IngestedNewRollup: bs.FoundNewRollup,
 	}
 }
 
 // Todo - implement with crypto
-func decryptSecret(secret obscurocommon.EncryptedSharedEnclaveSecret) SharedEnclaveSecret {
-	return SharedEnclaveSecret(secret)
+func decryptSecret(secret obscurocommon.EncryptedSharedEnclaveSecret) obscurocore.SharedEnclaveSecret {
+	return obscurocore.SharedEnclaveSecret(secret)
 }
 
 // Todo - implement with crypto
-func encryptSecret(secret SharedEnclaveSecret) obscurocommon.EncryptedSharedEnclaveSecret {
+func encryptSecret(secret obscurocore.SharedEnclaveSecret) obscurocommon.EncryptedSharedEnclaveSecret {
 	return obscurocommon.EncryptedSharedEnclaveSecret(secret)
 }
 
 // internal structure to pass information.
 type speculativeWork struct {
 	found bool
-	r     *Rollup
-	s     *State
+	r     *obscurocore.Rollup
+	s     *db.State
 	h     *nodecommon.Header
 	txs   []nodecommon.L2Tx
 }
 
 // internal structure used for the speculative execution.
 type processingEnvironment struct {
-	headRollup      *Rollup
+	headRollup      *obscurocore.Rollup
 	header          *nodecommon.Header
-	state           *State
+	state           *db.State
 	processedTxs    []nodecommon.L2Tx
 	processedTxsMap map[common.Hash]nodecommon.L2Tx
 }
@@ -458,7 +458,7 @@ type processingEnvironment struct {
 // `genesisJSON` is the configuration for the corresponding L1's genesis block. This is used to validate the blocks
 // received from the L1 node if `validateBlocks` is set to true.
 func NewEnclave(id common.Address, mining bool, txHandler mgmtcontractlib.TxHandler, validateBlocks bool, genesisJSON []byte, collector StatsCollector) nodecommon.Enclave {
-	storage := NewStorage()
+	storage := db.NewStorage()
 
 	var l1Blockchain *core.BlockChain
 	if validateBlocks {
@@ -478,7 +478,7 @@ func NewEnclave(id common.Address, mining bool, txHandler mgmtcontractlib.TxHand
 		statsCollector:       collector,
 		l1Blockchain:         l1Blockchain,
 		txCh:                 make(chan nodecommon.L2Tx),
-		roundWinnerCh:        make(chan *Rollup),
+		roundWinnerCh:        make(chan *obscurocore.Rollup),
 		exitCh:               make(chan bool),
 		speculativeWorkInCh:  make(chan bool),
 		speculativeWorkOutCh: make(chan speculativeWork),

--- a/go/obscuronode/enclave/enclave_test.go
+++ b/go/obscuronode/enclave/enclave_test.go
@@ -4,7 +4,7 @@ import (
 	"math/big"
 	"testing"
 
-	core2 "github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
+	obscurocore "github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
@@ -15,7 +15,7 @@ import (
 )
 
 func TestValidSignatureVerifies(t *testing.T) {
-	tx := core2.CreateL2Tx()
+	tx := obscurocore.CreateL2Tx()
 	privateKey, _ := crypto.GenerateKey()
 	signer := types.NewLondonSigner(big.NewInt(ChainID))
 	signedTx, _ := types.SignTx(tx, signer, privateKey)
@@ -26,7 +26,7 @@ func TestValidSignatureVerifies(t *testing.T) {
 }
 
 func TestUnsignedTxDoesNotVerify(t *testing.T) {
-	tx := core2.CreateL2Tx()
+	tx := obscurocore.CreateL2Tx()
 
 	if err := verifySignature(tx); err == nil {
 		t.Errorf("transaction was not signed but verified anyway: %v", err)
@@ -34,7 +34,7 @@ func TestUnsignedTxDoesNotVerify(t *testing.T) {
 }
 
 func TestModifiedTxDoesNotVerify(t *testing.T) {
-	txData := core2.CreateL2TxData()
+	txData := obscurocore.CreateL2TxData()
 	tx := types.NewTx(txData)
 	privateKey, _ := crypto.GenerateKey()
 	signer := types.NewLondonSigner(big.NewInt(ChainID))
@@ -49,7 +49,7 @@ func TestModifiedTxDoesNotVerify(t *testing.T) {
 }
 
 func TestIncorrectSignerDoesNotVerify(t *testing.T) {
-	tx := core2.CreateL2Tx()
+	tx := obscurocore.CreateL2Tx()
 	privateKey, _ := crypto.GenerateKey()
 	incorrectChainID := int64(ChainID + 1)
 	signer := types.NewLondonSigner(big.NewInt(incorrectChainID))

--- a/go/obscuronode/enclave/enclave_test.go
+++ b/go/obscuronode/enclave/enclave_test.go
@@ -4,6 +4,8 @@ import (
 	"math/big"
 	"testing"
 
+	core2 "github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/trie"
@@ -13,7 +15,7 @@ import (
 )
 
 func TestValidSignatureVerifies(t *testing.T) {
-	tx := createL2Tx()
+	tx := core2.CreateL2Tx()
 	privateKey, _ := crypto.GenerateKey()
 	signer := types.NewLondonSigner(big.NewInt(ChainID))
 	signedTx, _ := types.SignTx(tx, signer, privateKey)
@@ -24,7 +26,7 @@ func TestValidSignatureVerifies(t *testing.T) {
 }
 
 func TestUnsignedTxDoesNotVerify(t *testing.T) {
-	tx := createL2Tx()
+	tx := core2.CreateL2Tx()
 
 	if err := verifySignature(tx); err == nil {
 		t.Errorf("transaction was not signed but verified anyway: %v", err)
@@ -32,7 +34,7 @@ func TestUnsignedTxDoesNotVerify(t *testing.T) {
 }
 
 func TestModifiedTxDoesNotVerify(t *testing.T) {
-	txData := createL2TxData()
+	txData := core2.CreateL2TxData()
 	tx := types.NewTx(txData)
 	privateKey, _ := crypto.GenerateKey()
 	signer := types.NewLondonSigner(big.NewInt(ChainID))
@@ -47,7 +49,7 @@ func TestModifiedTxDoesNotVerify(t *testing.T) {
 }
 
 func TestIncorrectSignerDoesNotVerify(t *testing.T) {
-	tx := createL2Tx()
+	tx := core2.CreateL2Tx()
 	privateKey, _ := crypto.GenerateKey()
 	incorrectChainID := int64(ChainID + 1)
 	signer := types.NewLondonSigner(big.NewInt(incorrectChainID))

--- a/go/obscuronode/enclave/state.go
+++ b/go/obscuronode/enclave/state.go
@@ -6,9 +6,10 @@ import (
 	"math"
 	"math/big"
 
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/db"
 
-	"github.com/obscuronet/obscuro-playground/go/hashing"
+	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
 
 	"github.com/ethereum/go-ethereum/rlp"
 
@@ -16,60 +17,19 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 )
-
-// State - this is a placeholder for the real Trie based state
-//- people send transactions to an ObsERC20 that was a withdraw(amount, from, destination) method
-//In the EVM, there will be a smart contract that does the following:
-//- the tokens are deducted from the "from" address , and burned
-//- add to the "withdrawals" transactions - this info will be taken from the state
-//Post processing, outside the evm:
-//- generate withdrawal instructions (amount, destination), based on which withdrawal transaction were executed successfully
-type State struct {
-	balances    map[common.Address]uint64
-	withdrawals []obscurocommon.TxHash
-}
-
-// blockState - Represents the state after an L1 block was processed.
-type blockState struct {
-	block          *types.Block
-	head           *Rollup
-	state          *State
-	foundNewRollup bool
-}
-
-func copyState(state *State) *State {
-	s := emptyState()
-	if state == nil {
-		return s
-	}
-	for address, balance := range state.balances {
-		s.balances[address] = balance
-	}
-	s.withdrawals = append(s.withdrawals, state.withdrawals...)
-	return s
-}
-
-func serialize(state *State) nodecommon.StateRoot {
-	hash, err := hashing.RLPHash(fmt.Sprintf("%v", state))
-	if err != nil {
-		panic(err)
-	}
-	return hash
-}
 
 // returns a modified copy of the State
 // header - the header of the rollup where this transaction will be included
 // todo - remove nolint after the header starts being used
 func executeTransactions(
 	txs []nodecommon.L2Tx,
-	state *State,
+	state *db.State,
 	header *nodecommon.Header, //nolint
-) *State {
-	s := copyState(state)
+) *db.State {
+	s := db.CopyState(state)
 	for _, tx := range txs {
 		executeTx(s, tx)
 	}
@@ -78,52 +38,46 @@ func executeTransactions(
 }
 
 // mutates the state
-func executeTx(s *State, tx nodecommon.L2Tx) {
-	switch TxData(&tx).Type {
-	case TransferTx:
+func executeTx(s *db.State, tx nodecommon.L2Tx) {
+	switch core.TxData(&tx).Type {
+	case core.TransferTx:
 		executeTransfer(s, tx)
-	case WithdrawalTx:
+	case core.WithdrawalTx:
 		executeWithdrawal(s, tx)
-	case DepositTx:
+	case core.DepositTx:
 		executeDeposit(s, tx)
 	default:
 		panic("Invalid transaction type")
 	}
 }
 
-func executeWithdrawal(s *State, tx nodecommon.L2Tx) {
-	if txData := TxData(&tx); s.balances[txData.From] >= txData.Amount {
-		s.balances[txData.From] -= txData.Amount
-		s.withdrawals = append(s.withdrawals, tx.Hash())
+func executeWithdrawal(s *db.State, tx nodecommon.L2Tx) {
+	if txData := core.TxData(&tx); s.Balances[txData.From] >= txData.Amount {
+		s.Balances[txData.From] -= txData.Amount
+		s.Withdrawals = append(s.Withdrawals, tx.Hash())
 	}
 }
 
-func executeTransfer(s *State, tx nodecommon.L2Tx) {
-	if txData := TxData(&tx); s.balances[txData.From] >= txData.Amount {
-		s.balances[txData.From] -= txData.Amount
-		s.balances[txData.To] += txData.Amount
+func executeTransfer(s *db.State, tx nodecommon.L2Tx) {
+	if txData := core.TxData(&tx); s.Balances[txData.From] >= txData.Amount {
+		s.Balances[txData.From] -= txData.Amount
+		s.Balances[txData.To] += txData.Amount
 	}
 }
 
-func executeDeposit(s *State, tx nodecommon.L2Tx) {
-	t := TxData(&tx)
-	v, f := s.balances[t.To]
+func executeDeposit(s *db.State, tx nodecommon.L2Tx) {
+	t := core.TxData(&tx)
+	v, f := s.Balances[t.To]
 	if f {
-		s.balances[t.To] = v + t.Amount
+		s.Balances[t.To] = v + t.Amount
 	} else {
-		s.balances[t.To] = t.Amount
-	}
-}
-
-func emptyState() *State {
-	return &State{
-		balances: map[common.Address]uint64{},
+		s.Balances[t.To] = t.Amount
 	}
 }
 
 // Determine the new canonical L2 head and calculate the State
 // Uses cache-ing to map the Head rollup and the State to each L1Node block.
-func updateState(b *types.Block, blockResolver BlockResolver, storage Storage, txHandler mgmtcontractlib.TxHandler) *blockState {
+func updateState(b *types.Block, blockResolver db.BlockResolver, storage db.Storage, txHandler mgmtcontractlib.TxHandler) *db.BlockState {
 	// This method is called recursively in case of Re-orgs. Stop when state was calculated already.
 	val, found := storage.FetchBlockState(b.Hash())
 	if found {
@@ -176,7 +130,7 @@ func updateState(b *types.Block, blockResolver BlockResolver, storage Storage, t
 	return bs
 }
 
-func handleGenesisRollup(b *types.Block, s Storage, rollups []*Rollup, genesisRollup *Rollup) (genesisState *blockState, isGenesis bool) {
+func handleGenesisRollup(b *types.Block, s db.Storage, rollups []*core.Rollup, genesisRollup *core.Rollup) (genesisState *db.BlockState, isGenesis bool) {
 	// the incoming block holds the genesis rollup
 	// calculate and return the new block state
 	// todo change this to an hardcoded hash on testnet/mainnet
@@ -187,11 +141,11 @@ func handleGenesisRollup(b *types.Block, s Storage, rollups []*Rollup, genesisRo
 		s.StoreGenesisRollup(genesis)
 
 		// The genesis rollup is part of the canonical chain and will be included in an L1 block by the first Aggregator.
-		bs := blockState{
-			block:          b,
-			head:           genesis,
-			state:          emptyState(),
-			foundNewRollup: true,
+		bs := db.BlockState{
+			Block:          b,
+			Head:           genesis,
+			State:          db.EmptyState(),
+			FoundNewRollup: true,
 		}
 		s.SetBlockState(b.Hash(), &bs)
 		return &bs, true
@@ -206,11 +160,11 @@ func handleGenesisRollup(b *types.Block, s Storage, rollups []*Rollup, genesisRo
 }
 
 // Calculate transactions to be included in the current rollup
-func currentTxs(head *Rollup, mempool []nodecommon.L2Tx, s Storage) []nodecommon.L2Tx {
+func currentTxs(head *core.Rollup, mempool []nodecommon.L2Tx, s db.Storage) []nodecommon.L2Tx {
 	return findTxsNotIncluded(head, mempool, s)
 }
 
-func FindWinner(parent *Rollup, rollups []*Rollup, blockResolver BlockResolver) (*Rollup, bool) {
+func FindWinner(parent *core.Rollup, rollups []*core.Rollup, blockResolver db.BlockResolver) (*core.Rollup, bool) {
 	win := -1
 	// todo - add statistics to determine why there are conflicts.
 	for i, r := range rollups {
@@ -219,8 +173,8 @@ func FindWinner(parent *Rollup, rollups []*Rollup, blockResolver BlockResolver) 
 		case r.Header.Height <= parent.Header.Height: // ignore rollups that are older than the parent
 		case win == -1:
 			win = i
-		case r.ProofHeight(blockResolver) < rollups[win].ProofHeight(blockResolver): // ignore rollups generated with an older proof
-		case r.ProofHeight(blockResolver) > rollups[win].ProofHeight(blockResolver): // newer rollups win
+		case blockResolver.ProofHeight(r) < blockResolver.ProofHeight(rollups[win]): // ignore rollups generated with an older proof
+		case blockResolver.ProofHeight(r) > blockResolver.ProofHeight(rollups[win]): // newer rollups win
 			win = i
 		case r.Header.Nonce < rollups[win].Header.Nonce: // for rollups with the same proof, base on the nonce
 			win = i
@@ -232,20 +186,20 @@ func FindWinner(parent *Rollup, rollups []*Rollup, blockResolver BlockResolver) 
 	return rollups[win], true
 }
 
-func (e *enclaveImpl) findRoundWinner(receivedRollups []*Rollup, parent *Rollup, parentState *State, s Storage, blockResolver BlockResolver) (*Rollup, *State) {
+func (e *enclaveImpl) findRoundWinner(receivedRollups []*core.Rollup, parent *core.Rollup, parentState *db.State, s db.Storage, blockResolver db.BlockResolver) (*core.Rollup, *db.State) {
 	headRollup, found := FindWinner(parent, receivedRollups, blockResolver)
 	if !found {
 		panic("This should not happen for gossip rounds.")
 	}
 	// calculate the state to compare with what is in the Rollup
-	p := s.ParentRollup(headRollup).Proof(blockResolver)
-	depositTxs := processDeposits(p, headRollup.Proof(blockResolver), blockResolver, e.txHandler)
+	p := blockResolver.Proof(s.ParentRollup(headRollup))
+	depositTxs := processDeposits(p, blockResolver.Proof(headRollup), blockResolver, e.txHandler)
 
 	state := executeTransactions(append(headRollup.Transactions, depositTxs...), parentState, headRollup.Header)
 
-	if serialize(state) != headRollup.Header.State {
+	if db.Serialize(state) != headRollup.Header.State {
 		panic(fmt.Sprintf("Calculated a different state. This should not happen as there are no malicious actors yet. \nGot: %s\nExp: %s\nParent state:%v\nParent state:%s\nTxs:%v",
-			serialize(state),
+			db.Serialize(state),
 			headRollup.Header.State,
 			parentState,
 			parent.Header.State,
@@ -259,7 +213,7 @@ func (e *enclaveImpl) findRoundWinner(receivedRollups []*Rollup, parent *Rollup,
 
 // returns a list of L2 deposit transactions generated from the L1 deposit transactions
 // starting with the proof of the parent rollup(exclusive) to the proof of the current rollup
-func processDeposits(fromBlock *types.Block, toBlock *types.Block, blockResolver BlockResolver, txHandler mgmtcontractlib.TxHandler) []nodecommon.L2Tx {
+func processDeposits(fromBlock *types.Block, toBlock *types.Block, blockResolver db.BlockResolver, txHandler mgmtcontractlib.TxHandler) []nodecommon.L2Tx {
 	from := obscurocommon.GenesisBlock.Hash()
 	height := obscurocommon.L1GenesisHeight
 	if fromBlock != nil {
@@ -280,8 +234,8 @@ func processDeposits(fromBlock *types.Block, toBlock *types.Block, blockResolver
 			t := txHandler.UnPackTx(tx)
 			// transactions to a hardcoded bridge address
 			if t != nil && t.TxType == obscurocommon.DepositTx {
-				depL2TxData := L2TxData{
-					Type:   DepositTx,
+				depL2TxData := core.L2TxData{
+					Type:   core.DepositTx,
 					To:     t.Dest,
 					Amount: t.Amount,
 				}
@@ -302,42 +256,42 @@ func processDeposits(fromBlock *types.Block, toBlock *types.Block, blockResolver
 }
 
 // given an L1 block, and the State as it was in the Parent block, calculates the State after the current block.
-func calculateBlockState(b *types.Block, parentState *blockState, s Storage, blockResolver BlockResolver, rollups []*Rollup, txHandler mgmtcontractlib.TxHandler) *blockState {
-	currentHead := parentState.head
+func calculateBlockState(b *types.Block, parentState *db.BlockState, s db.Storage, blockResolver db.BlockResolver, rollups []*core.Rollup, txHandler mgmtcontractlib.TxHandler) *db.BlockState {
+	currentHead := parentState.Head
 	newHeadRollup, found := FindWinner(currentHead, rollups, blockResolver)
-	newState := parentState.state
+	newState := parentState.State
 	// only change the state if there is a new l2 Head in the current block
 	if found {
 		// Preprocessing before passing to the vm
 		// todo transform into an eth block structure
 		parentRollup := s.ParentRollup(newHeadRollup)
-		p := parentRollup.Proof(blockResolver)
-		depositTxs := processDeposits(p, newHeadRollup.Proof(blockResolver), blockResolver, txHandler)
+		p := blockResolver.Proof(parentRollup)
+		depositTxs := processDeposits(p, blockResolver.Proof(newHeadRollup), blockResolver, txHandler)
 
 		// deposits have to be processed after the normal transactions were executed because during speculative execution they are not available
 		txsToProcess := append(newHeadRollup.Transactions, depositTxs...)
-		newState = executeTransactions(txsToProcess, parentState.state, newHeadRollup.Header)
+		newState = executeTransactions(txsToProcess, parentState.State, newHeadRollup.Header)
 	} else {
-		newHeadRollup = parentState.head
+		newHeadRollup = parentState.Head
 	}
 
-	bs := blockState{
-		block:          b,
-		head:           newHeadRollup,
-		state:          newState,
-		foundNewRollup: found,
+	bs := db.BlockState{
+		Block:          b,
+		Head:           newHeadRollup,
+		State:          newState,
+		FoundNewRollup: found,
 	}
 	return &bs
 }
 
 // Todo - this has to be implemented differently based on how we define the ObsERC20
-func rollupPostProcessingWithdrawals(newHeadRollup *Rollup, newState *State) []nodecommon.Withdrawal {
+func rollupPostProcessingWithdrawals(newHeadRollup *core.Rollup, newState *db.State) []nodecommon.Withdrawal {
 	w := make([]nodecommon.Withdrawal, 0)
 
 	// go through each transaction and check if the withdrawal was processed correctly
 	for i, t := range newHeadRollup.Transactions {
-		txData := TxData(&newHeadRollup.Transactions[i])
-		if txData.Type == WithdrawalTx && contains(newState.withdrawals, t.Hash()) {
+		txData := core.TxData(&newHeadRollup.Transactions[i])
+		if txData.Type == core.WithdrawalTx && contains(newState.Withdrawals, t.Hash()) {
 			w = append(w, nodecommon.Withdrawal{
 				Amount:  txData.Amount,
 				Address: txData.From,
@@ -347,8 +301,8 @@ func rollupPostProcessingWithdrawals(newHeadRollup *Rollup, newState *State) []n
 	return w
 }
 
-func extractRollups(b *types.Block, blockResolver BlockResolver, handler mgmtcontractlib.TxHandler) []*Rollup {
-	rollups := make([]*Rollup, 0)
+func extractRollups(b *types.Block, blockResolver db.BlockResolver, handler mgmtcontractlib.TxHandler) []*core.Rollup {
+	rollups := make([]*core.Rollup, 0)
 	for _, tx := range b.Transactions() {
 		// go through all rollup transactions
 		t := handler.UnPackTx(tx)
@@ -365,14 +319,14 @@ func extractRollups(b *types.Block, blockResolver BlockResolver, handler mgmtcon
 	return rollups
 }
 
-func toEnclaveRollup(r *nodecommon.Rollup) *Rollup {
-	return &Rollup{
+func toEnclaveRollup(r *nodecommon.Rollup) *core.Rollup {
+	return &core.Rollup{
 		Header:       r.Header,
-		Transactions: decryptTransactions(r.Transactions),
+		Transactions: core.DecryptTransactions(r.Transactions),
 	}
 }
 
-func newL2Tx(data L2TxData) *nodecommon.L2Tx {
+func newL2Tx(data core.L2TxData) *nodecommon.L2Tx {
 	// We should probably use a deterministic nonce instead, as in the L1.
 	nonce, _ := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
 

--- a/go/obscuronode/enclave/utils.go
+++ b/go/obscuronode/enclave/utils.go
@@ -3,6 +3,9 @@ package enclave
 import (
 	"fmt"
 
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/db"
+
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -12,12 +15,12 @@ import (
 
 // findTxsNotIncluded - given a list of transactions, it keeps only the ones that were not included in the block
 // todo - inefficient
-func findTxsNotIncluded(head *Rollup, txs []nodecommon.L2Tx, s Storage) []nodecommon.L2Tx {
+func findTxsNotIncluded(head *core.Rollup, txs []nodecommon.L2Tx, s db.Storage) []nodecommon.L2Tx {
 	included := allIncludedTransactions(head, s)
 	return removeExisting(txs, included)
 }
 
-func allIncludedTransactions(b *Rollup, s Storage) map[common.Hash]nodecommon.L2Tx {
+func allIncludedTransactions(b *core.Rollup, s db.Storage) map[common.Hash]nodecommon.L2Tx {
 	val, found := s.FetchRollupTxs(b)
 	if found {
 		return val
@@ -47,7 +50,7 @@ func removeExisting(base []nodecommon.L2Tx, toRemove map[common.Hash]nodecommon.
 }
 
 // Returns all transactions found 20 levels below
-func historicTxs(r *Rollup, s Storage) map[common.Hash]common.Hash {
+func historicTxs(r *core.Rollup, s db.Storage) map[common.Hash]common.Hash {
 	i := obscurocommon.HeightCommittedBlocks
 	c := r
 	for {
@@ -83,13 +86,13 @@ func printTxs(txs []nodecommon.L2Tx) (txsString []string) {
 }
 
 func printTx(t nodecommon.L2Tx, txsString []string) []string {
-	txData := TxData(&t)
+	txData := core.TxData(&t)
 	switch txData.Type {
-	case TransferTx:
+	case core.TransferTx:
 		txsString = append(txsString, fmt.Sprintf("%d->%d(%d){%d}", obscurocommon.ShortAddress(txData.From), obscurocommon.ShortAddress(txData.To), txData.Amount, obscurocommon.ShortHash(t.Hash())))
-	case WithdrawalTx:
+	case core.WithdrawalTx:
 		txsString = append(txsString, fmt.Sprintf("%d->*(%d){%d}", obscurocommon.ShortAddress(txData.From), txData.Amount, obscurocommon.ShortHash(t.Hash())))
-	case DepositTx:
+	case core.DepositTx:
 		txsString = append(txsString, fmt.Sprintf("*->%d(%d){%d}", obscurocommon.ShortAddress(txData.To), txData.Amount, obscurocommon.ShortHash(t.Hash())))
 	}
 	return txsString

--- a/integration/ethereummock/db.go
+++ b/integration/ethereummock/db.go
@@ -3,9 +3,10 @@ package ethereummock
 import (
 	"sync"
 
-	"github.com/obscuronet/obscuro-playground/go/log"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/db"
 
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave"
+	"github.com/obscuronet/obscuro-playground/go/log"
 
 	"github.com/ethereum/go-ethereum/core/types"
 
@@ -23,7 +24,15 @@ type blockResolverInMem struct {
 	m          sync.RWMutex
 }
 
-func NewResolver() enclave.BlockResolver {
+func (n *blockResolverInMem) ProofHeight(_ *core.Rollup) int64 {
+	panic("implement me")
+}
+
+func (n *blockResolverInMem) Proof(_ *core.Rollup) *types.Block {
+	panic("implement me")
+}
+
+func NewResolver() db.BlockResolver {
 	return &blockResolverInMem{
 		blockCache: map[obscurocommon.L1RootHash]blockAndHeight{},
 		m:          sync.RWMutex{},
@@ -159,7 +168,7 @@ func (n *txDBInMem) AddTxs(b *types.Block, newMap map[obscurocommon.TxHash]*obsc
 func removeCommittedTransactions(
 	cb *types.Block,
 	mempool []*obscurocommon.L1Tx,
-	resolver enclave.BlockResolver,
+	resolver db.BlockResolver,
 	db TxDB,
 ) []*obscurocommon.L1Tx {
 	if resolver.HeightBlock(cb) <= obscurocommon.HeightCommittedBlocks {

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -6,11 +6,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/db"
+
 	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
 
 	"github.com/obscuronet/obscuro-playground/go/ethclient"
-
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave"
 
 	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 
@@ -48,7 +48,7 @@ type Node struct {
 	Network  L1Network
 	mining   bool
 	stats    StatsCollector
-	Resolver enclave.BlockResolver
+	Resolver db.BlockResolver
 	db       TxDB
 
 	// Channels
@@ -67,11 +67,11 @@ type Node struct {
 	txHandler mgmtcontractlib.TxHandler
 }
 
-func (m *Node) SubmitTransaction(tx types.TxData) (*types.Transaction, error) {
+func (m *Node) SubmitTransaction(_ types.TxData) (*types.Transaction, error) {
 	panic("method should never be called in this mock")
 }
 
-func (m *Node) FetchTxReceipt(hash common.Hash) (*types.Receipt, error) {
+func (m *Node) FetchTxReceipt(_ common.Hash) (*types.Receipt, error) {
 	panic("method should never be called in this mock")
 }
 

--- a/integration/ethereummock/utils.go
+++ b/integration/ethereummock/utils.go
@@ -3,11 +3,11 @@ package ethereummock
 import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave"
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/db"
 )
 
 // LCA - returns the least common ancestor of the 2 blocks
-func LCA(blockA *types.Block, blockB *types.Block, resolver enclave.BlockResolver) *types.Block {
+func LCA(blockA *types.Block, blockB *types.Block, resolver db.BlockResolver) *types.Block {
 	if resolver.HeightBlock(blockA) == obscurocommon.L1GenesisHeight || resolver.HeightBlock(blockB) == obscurocommon.L1GenesisHeight {
 		return blockA
 	}
@@ -43,12 +43,12 @@ func LCA(blockA *types.Block, blockB *types.Block, resolver enclave.BlockResolve
 
 // findNotIncludedTxs - given a list of transactions, it keeps only the ones that were not included in the block
 // todo - inefficient
-func findNotIncludedTxs(head *types.Block, txs []*obscurocommon.L1Tx, r enclave.BlockResolver, db TxDB) []*obscurocommon.L1Tx {
+func findNotIncludedTxs(head *types.Block, txs []*obscurocommon.L1Tx, r db.BlockResolver, db TxDB) []*obscurocommon.L1Tx {
 	included := allIncludedTransactions(head, r, db)
 	return removeExisting(txs, included)
 }
 
-func allIncludedTransactions(b *types.Block, r enclave.BlockResolver, db TxDB) map[obscurocommon.TxHash]*obscurocommon.L1Tx {
+func allIncludedTransactions(b *types.Block, r db.BlockResolver, db TxDB) map[obscurocommon.TxHash]*obscurocommon.L1Tx {
 	val, found := db.Txs(b)
 	if found {
 		return val

--- a/integration/walletmock/wallet.go
+++ b/integration/walletmock/wallet.go
@@ -7,6 +7,8 @@ import (
 	"math"
 	"math/big"
 
+	"github.com/obscuronet/obscuro-playground/go/obscuronode/enclave/core"
+
 	"github.com/obscuronet/obscuro-playground/go/obscuronode/nodecommon"
 
 	"github.com/ethereum/go-ethereum/core/types"
@@ -47,13 +49,13 @@ func New() Wallet {
 
 // NewL2Transfer creates an enclave.L2Tx of type enclave.TransferTx
 func NewL2Transfer(from common.Address, dest common.Address, amount uint64) *nodecommon.L2Tx {
-	txData := enclave.L2TxData{Type: enclave.TransferTx, From: from, To: dest, Amount: amount}
+	txData := core.L2TxData{Type: core.TransferTx, From: from, To: dest, Amount: amount}
 	return NewL2Tx(txData)
 }
 
 // NewL2Withdrawal creates an enclave.L2Tx of type enclave.WithdrawalTx
 func NewL2Withdrawal(from common.Address, amount uint64) *nodecommon.L2Tx {
-	txData := enclave.L2TxData{Type: enclave.WithdrawalTx, From: from, Amount: amount}
+	txData := core.L2TxData{Type: core.WithdrawalTx, From: from, Amount: amount}
 	return NewL2Tx(txData)
 }
 
@@ -61,7 +63,7 @@ func NewL2Withdrawal(from common.Address, amount uint64) *nodecommon.L2Tx {
 //
 // A random nonce is used to avoid hash collisions. The enclave.L2TxData is encoded and stored in the transaction's
 // data field.
-func NewL2Tx(data enclave.L2TxData) *nodecommon.L2Tx {
+func NewL2Tx(data core.L2TxData) *nodecommon.L2Tx {
 	// We should probably use a deterministic nonce instead, as in the L1.
 	nonce, _ := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
 


### PR DESCRIPTION
- prerequisite for adding the geth StateDB
- this PR doesn't change any functionality
- moves all db stuff in a new package
- to avoid circular dependencies, it also move some core types to a "core" package
