### PR TITLE
Road to statedb - part 2

### DIFF
--- a/go/obscuronode/enclave/db/db.go
+++ b/go/obscuronode/enclave/db/db.go
@@ -34,7 +34,7 @@ type inMemoryDB struct {
 	sharedEnclaveSecret core.SharedEnclaveSecret
 }
 
-func newInMemoryDB() *inMemoryDB {
+func NewInMemoryDB() *inMemoryDB {
 	return &inMemoryDB{
 		statePerBlock:     make(map[obscurocommon.L1RootHash]*BlockState),
 		stateMutex:        sync.RWMutex{},
@@ -81,7 +81,6 @@ func (db *inMemoryDB) SetBlockStateNewRollup(hash obscurocommon.L1RootHash, stat
 
 	db.statePerBlock[hash] = state
 	db.rollups[state.Head.Hash()] = state.Head
-	db.statePerRollup[state.Head.Hash()] = state.State
 	// todo - is there any other logic here?
 	db.headBlock = hash
 }

--- a/go/obscuronode/enclave/db/db.go
+++ b/go/obscuronode/enclave/db/db.go
@@ -16,7 +16,7 @@ import (
 
 // DB lives purely in the encrypted memory space of an enclave.
 // Unlike Storage, methods in this class should have minimal logic, to map them more easily to our chosen datastore.
-type inMemoryDB struct {
+type InMemoryDB struct {
 	rollupGenesisHash common.Hash // TODO add lock protection, not needed atm
 
 	stateMutex sync.RWMutex // Controls access to `statePerBlock`, `statePerRollup`, `headBlock`, `rollupsByHeight` and `rollups`
@@ -34,8 +34,8 @@ type inMemoryDB struct {
 	sharedEnclaveSecret core.SharedEnclaveSecret
 }
 
-func NewInMemoryDB() *inMemoryDB {
-	return &inMemoryDB{
+func NewInMemoryDB() *InMemoryDB {
+	return &InMemoryDB{
 		statePerBlock:     make(map[obscurocommon.L1RootHash]*BlockState),
 		stateMutex:        sync.RWMutex{},
 		rollupsByHeight:   make(map[uint64][]*core.Rollup),
@@ -48,17 +48,17 @@ func NewInMemoryDB() *inMemoryDB {
 	}
 }
 
-func (db *inMemoryDB) StoreGenesisRollup(rol *core.Rollup) {
+func (db *InMemoryDB) StoreGenesisRollup(rol *core.Rollup) {
 	db.rollupGenesisHash = rol.Hash()
 	db.StoreRollup(rol)
 }
 
-func (db *inMemoryDB) FetchGenesisRollup() *core.Rollup {
+func (db *InMemoryDB) FetchGenesisRollup() *core.Rollup {
 	r, _ := db.FetchRollup(db.rollupGenesisHash)
 	return r
 }
 
-func (db *inMemoryDB) FetchBlockState(hash obscurocommon.L1RootHash) (*BlockState, bool) {
+func (db *InMemoryDB) FetchBlockState(hash obscurocommon.L1RootHash) (*BlockState, bool) {
 	db.stateMutex.RLock()
 	defer db.stateMutex.RUnlock()
 
@@ -66,7 +66,7 @@ func (db *inMemoryDB) FetchBlockState(hash obscurocommon.L1RootHash) (*BlockStat
 	return val, found
 }
 
-func (db *inMemoryDB) SetBlockState(hash obscurocommon.L1RootHash, state *BlockState) {
+func (db *InMemoryDB) SetBlockState(hash obscurocommon.L1RootHash, state *BlockState) {
 	db.stateMutex.Lock()
 	defer db.stateMutex.Unlock()
 
@@ -75,7 +75,7 @@ func (db *inMemoryDB) SetBlockState(hash obscurocommon.L1RootHash, state *BlockS
 	db.headBlock = hash
 }
 
-func (db *inMemoryDB) SetBlockStateNewRollup(hash obscurocommon.L1RootHash, state *BlockState) {
+func (db *InMemoryDB) SetBlockStateNewRollup(hash obscurocommon.L1RootHash, state *BlockState) {
 	db.stateMutex.Lock()
 	defer db.stateMutex.Unlock()
 
@@ -85,19 +85,19 @@ func (db *inMemoryDB) SetBlockStateNewRollup(hash obscurocommon.L1RootHash, stat
 	db.headBlock = hash
 }
 
-func (db *inMemoryDB) SetRollupState(hash obscurocommon.L2RootHash, state *State) {
+func (db *InMemoryDB) SetRollupState(hash obscurocommon.L2RootHash, state *State) {
 	db.stateMutex.Lock()
 	defer db.stateMutex.Unlock()
 
 	db.statePerRollup[hash] = state
 }
 
-func (db *inMemoryDB) FetchHeadBlock() obscurocommon.L1RootHash {
+func (db *InMemoryDB) FetchHeadBlock() obscurocommon.L1RootHash {
 	return db.headBlock
 }
 
 // TODO - Pull this logic into the storage layer.
-func (db *inMemoryDB) StoreRollup(rollup *core.Rollup) {
+func (db *InMemoryDB) StoreRollup(rollup *core.Rollup) {
 	db.stateMutex.Lock()
 	defer db.stateMutex.Unlock()
 
@@ -110,7 +110,7 @@ func (db *inMemoryDB) StoreRollup(rollup *core.Rollup) {
 	}
 }
 
-func (db *inMemoryDB) FetchRollup(hash obscurocommon.L2RootHash) (*core.Rollup, bool) {
+func (db *InMemoryDB) FetchRollup(hash obscurocommon.L2RootHash) (*core.Rollup, bool) {
 	db.stateMutex.RLock()
 	defer db.stateMutex.RUnlock()
 
@@ -118,28 +118,28 @@ func (db *inMemoryDB) FetchRollup(hash obscurocommon.L2RootHash) (*core.Rollup, 
 	return r, f
 }
 
-func (db *inMemoryDB) FetchRollups(height uint64) []*core.Rollup {
+func (db *InMemoryDB) FetchRollups(height uint64) []*core.Rollup {
 	db.stateMutex.RLock()
 	defer db.stateMutex.RUnlock()
 
 	return db.rollupsByHeight[height]
 }
 
-func (db *inMemoryDB) FetchRollupState(hash obscurocommon.L2RootHash) *State {
+func (db *InMemoryDB) FetchRollupState(hash obscurocommon.L2RootHash) *State {
 	db.stateMutex.RLock()
 	defer db.stateMutex.RUnlock()
 
 	return db.statePerRollup[hash]
 }
 
-func (db *inMemoryDB) StoreBlock(b *types.Block) {
+func (db *InMemoryDB) StoreBlock(b *types.Block) {
 	db.blockMutex.Lock()
 	defer db.blockMutex.Unlock()
 
 	db.blockCache[b.Hash()] = b
 }
 
-func (db *inMemoryDB) FetchBlock(hash obscurocommon.L1RootHash) (*types.Block, bool) {
+func (db *InMemoryDB) FetchBlock(hash obscurocommon.L1RootHash) (*types.Block, bool) {
 	db.blockMutex.RLock()
 	defer db.blockMutex.RUnlock()
 
@@ -147,7 +147,7 @@ func (db *inMemoryDB) FetchBlock(hash obscurocommon.L1RootHash) (*types.Block, b
 	return val, f
 }
 
-func (db *inMemoryDB) FetchRollupTxs(r *core.Rollup) (map[common.Hash]nodecommon.L2Tx, bool) {
+func (db *InMemoryDB) FetchRollupTxs(r *core.Rollup) (map[common.Hash]nodecommon.L2Tx, bool) {
 	db.txMutex.RLock()
 	defer db.txMutex.RUnlock()
 
@@ -155,17 +155,17 @@ func (db *inMemoryDB) FetchRollupTxs(r *core.Rollup) (map[common.Hash]nodecommon
 	return val, found
 }
 
-func (db *inMemoryDB) StoreRollupTxs(r *core.Rollup, newMap map[common.Hash]nodecommon.L2Tx) {
+func (db *InMemoryDB) StoreRollupTxs(r *core.Rollup, newMap map[common.Hash]nodecommon.L2Tx) {
 	db.txMutex.Lock()
 	defer db.txMutex.Unlock()
 
 	db.txsPerRollupCache[r.Hash()] = newMap
 }
 
-func (db *inMemoryDB) StoreSecret(secret core.SharedEnclaveSecret) {
+func (db *InMemoryDB) StoreSecret(secret core.SharedEnclaveSecret) {
 	db.sharedEnclaveSecret = secret
 }
 
-func (db *inMemoryDB) FetchSecret() core.SharedEnclaveSecret {
+func (db *InMemoryDB) FetchSecret() core.SharedEnclaveSecret {
 	return db.sharedEnclaveSecret
 }

--- a/go/obscuronode/enclave/db/interfaces.go
+++ b/go/obscuronode/enclave/db/interfaces.go
@@ -42,19 +42,36 @@ type RollupResolver interface {
 	FetchRollupTxs(rollup *core.Rollup) (map[common.Hash]nodecommon.L2Tx, bool)
 	// StoreRollupTxs overwrites the transactions associated with a given rollup
 	StoreRollupTxs(rollup *core.Rollup, newTxs map[common.Hash]nodecommon.L2Tx)
+	// StoreGenesisRollup stores the rollup genesis
+	StoreGenesisRollup(rol *core.Rollup)
+	// FetchGenesisRollup returns the rollup genesis
+	FetchGenesisRollup() *core.Rollup
 }
 
-type StateStorage interface {
-	// FetchBlockState returns the state after ingesting the L1 Block with the given hash
-	FetchBlockState(hash obscurocommon.L1RootHash) (*BlockState, bool)
-	// FetchHeadState returns the state after ingesting the L1 Block at the head of the chain
+type BlockStateStorage interface {
+	// FetchBlockState returns the head rollup found in the block
+	FetchBlockState(blockHash obscurocommon.L1RootHash) (*BlockState, bool)
+	// FetchHeadState returns the head roolup
 	FetchHeadState() *BlockState
-	// SetBlockState persists the state after ingesting the L1 Block with the given hash
-	SetBlockState(hash obscurocommon.L1RootHash, state *BlockState)
-	// FetchRollupState returns the state after adding the rollup with the given hash
-	FetchRollupState(hash obscurocommon.L2RootHash) *State
-	// SetRollupState persists the state after adding the rollup with the given hash
-	SetRollupState(hash obscurocommon.L2RootHash, state *State)
+	// SetBlockState save the rollup-block mapping
+	SetBlockState(blockHash obscurocommon.L1RootHash, state *BlockState)
+	// CreateStateDb create a database that can be used to execute transactions
+	CreateStateDb(hash obscurocommon.L2RootHash) StateDb
+	// GenesisStateDb create the original empty StateDb
+	GenesisStateDb() StateDb
+}
+
+// StateDb - is the conceptual equivalent of the geth vm.StateDb
+type StateDb interface {
+	GetBalance(address common.Address) uint64
+	SetBalance(address common.Address, balance uint64)
+	AddWithdrawal(txHash obscurocommon.TxHash)
+	Copy() StateDb
+	StateRoot() common.Hash
+	Withdrawals() []obscurocommon.TxHash
+
+	// Commit saves the changes made during transaction execution to a persistent db
+	Commit(currentRoot obscurocommon.L2RootHash)
 }
 
 type SharedSecretStorage interface {
@@ -62,11 +79,6 @@ type SharedSecretStorage interface {
 	FetchSecret() core.SharedEnclaveSecret
 	// StoreSecret stores a secret in the enclave
 	StoreSecret(secret core.SharedEnclaveSecret)
-
-	// StoreGenesisRollup stores the rollup genesis
-	StoreGenesisRollup(rol *core.Rollup)
-	// FetchGenesisRollup returns the rollup genesis
-	FetchGenesisRollup() *core.Rollup
 }
 
 // Storage is the enclave's interface for interacting with the enclave's datastore
@@ -74,5 +86,5 @@ type Storage interface {
 	BlockResolver
 	RollupResolver
 	SharedSecretStorage
-	StateStorage
+	BlockStateStorage
 }

--- a/go/obscuronode/enclave/db/interfaces.go
+++ b/go/obscuronode/enclave/db/interfaces.go
@@ -55,18 +55,18 @@ type BlockStateStorage interface {
 	FetchHeadState() *BlockState
 	// SetBlockState save the rollup-block mapping
 	SetBlockState(blockHash obscurocommon.L1RootHash, state *BlockState)
-	// CreateStateDb create a database that can be used to execute transactions
-	CreateStateDb(hash obscurocommon.L2RootHash) StateDb
-	// GenesisStateDb create the original empty StateDb
-	GenesisStateDb() StateDb
+	// CreateStateDB create a database that can be used to execute transactions
+	CreateStateDB(hash obscurocommon.L2RootHash) StateDB
+	// GenesisStateDB create the original empty StateDB
+	GenesisStateDB() StateDB
 }
 
-// StateDb - is the conceptual equivalent of the geth vm.StateDb
-type StateDb interface {
+// StateDB - is the conceptual equivalent of the geth vm.StateDB
+type StateDB interface {
 	GetBalance(address common.Address) uint64
 	SetBalance(address common.Address, balance uint64)
 	AddWithdrawal(txHash obscurocommon.TxHash)
-	Copy() StateDb
+	Copy() StateDB
 	StateRoot() common.Hash
 	Withdrawals() []obscurocommon.TxHash
 

--- a/go/obscuronode/enclave/db/obscurostatedb.go
+++ b/go/obscuronode/enclave/db/obscurostatedb.go
@@ -5,46 +5,46 @@ import (
 	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
 )
 
-// this will eventually be the geth vm.StateDb
-type obscuroStateDb struct {
-	db         *inMemoryDB
+// this will eventually be the geth vm.StateDB
+type obscuroStateDB struct {
+	db         *InMemoryDB
 	parentRoot obscurocommon.L2RootHash // root of the parent
 	// currentRoot obscurocommon.L2RootHash
 	state *State
 }
 
-func NewStateDb(db *inMemoryDB, root obscurocommon.L2RootHash, parentState *State) StateDb {
-	return &obscuroStateDb{
+func NewStateDB(db *InMemoryDB, root obscurocommon.L2RootHash, parentState *State) StateDB {
+	return &obscuroStateDB{
 		parentRoot: root,
 		db:         db,
 		state:      parentState,
 	}
 }
 
-func (s *obscuroStateDb) GetBalance(address common.Address) uint64 {
+func (s *obscuroStateDB) GetBalance(address common.Address) uint64 {
 	return s.state.Balances[address]
 }
 
-func (s *obscuroStateDb) SetBalance(address common.Address, balance uint64) {
+func (s *obscuroStateDB) SetBalance(address common.Address, balance uint64) {
 	s.state.Balances[address] = balance
 }
 
-func (s *obscuroStateDb) AddWithdrawal(txHash obscurocommon.TxHash) {
+func (s *obscuroStateDB) AddWithdrawal(txHash obscurocommon.TxHash) {
 	s.state.Withdrawals = append(s.state.Withdrawals, txHash)
 }
 
-func (s *obscuroStateDb) Commit(currentRoot obscurocommon.L2RootHash) {
+func (s *obscuroStateDB) Commit(currentRoot obscurocommon.L2RootHash) {
 	s.db.SetRollupState(currentRoot, s.state)
 }
 
-func (s *obscuroStateDb) Copy() StateDb {
-	return NewStateDb(s.db, s.parentRoot, CopyState(s.state))
+func (s *obscuroStateDB) Copy() StateDB {
+	return NewStateDB(s.db, s.parentRoot, CopyState(s.state))
 }
 
-func (s *obscuroStateDb) StateRoot() common.Hash {
+func (s *obscuroStateDB) StateRoot() common.Hash {
 	return Serialize(s.state)
 }
 
-func (s *obscuroStateDb) Withdrawals() []obscurocommon.TxHash {
+func (s *obscuroStateDB) Withdrawals() []obscurocommon.TxHash {
 	return s.state.Withdrawals
 }

--- a/go/obscuronode/enclave/db/obscurostatedb.go
+++ b/go/obscuronode/enclave/db/obscurostatedb.go
@@ -1,0 +1,50 @@
+package db
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
+)
+
+// this will eventually be the geth vm.StateDb
+type obscuroStateDb struct {
+	db         *inMemoryDB
+	parentRoot obscurocommon.L2RootHash // root of the parent
+	// currentRoot obscurocommon.L2RootHash
+	state *State
+}
+
+func NewStateDb(db *inMemoryDB, root obscurocommon.L2RootHash, parentState *State) StateDb {
+	return &obscuroStateDb{
+		parentRoot: root,
+		db:         db,
+		state:      parentState,
+	}
+}
+
+func (s *obscuroStateDb) GetBalance(address common.Address) uint64 {
+	return s.state.Balances[address]
+}
+
+func (s *obscuroStateDb) SetBalance(address common.Address, balance uint64) {
+	s.state.Balances[address] = balance
+}
+
+func (s *obscuroStateDb) AddWithdrawal(txHash obscurocommon.TxHash) {
+	s.state.Withdrawals = append(s.state.Withdrawals, txHash)
+}
+
+func (s *obscuroStateDb) Commit(currentRoot obscurocommon.L2RootHash) {
+	s.db.SetRollupState(currentRoot, s.state)
+}
+
+func (s *obscuroStateDb) Copy() StateDb {
+	return NewStateDb(s.db, s.parentRoot, CopyState(s.state))
+}
+
+func (s *obscuroStateDb) StateRoot() common.Hash {
+	return Serialize(s.state)
+}
+
+func (s *obscuroStateDb) Withdrawals() []obscurocommon.TxHash {
+	return s.state.Withdrawals
+}

--- a/go/obscuronode/enclave/db/storage.go
+++ b/go/obscuronode/enclave/db/storage.go
@@ -13,7 +13,7 @@ import (
 )
 
 type storageImpl struct {
-	db *inMemoryDB
+	db *InMemoryDB
 }
 
 func (s *storageImpl) StoreGenesisRollup(rol *core.Rollup) {
@@ -24,7 +24,7 @@ func (s *storageImpl) FetchGenesisRollup() *core.Rollup {
 	return s.db.FetchGenesisRollup()
 }
 
-func NewStorage(db *inMemoryDB) Storage {
+func NewStorage(db *InMemoryDB) Storage {
 	return &storageImpl{db: db}
 }
 
@@ -177,14 +177,14 @@ func (s *storageImpl) SetBlockState(hash obscurocommon.L1RootHash, state *BlockS
 	}
 }
 
-func (s *storageImpl) CreateStateDb(hash obscurocommon.L2RootHash) StateDb {
+func (s *storageImpl) CreateStateDB(hash obscurocommon.L2RootHash) StateDB {
 	parent := s.db.FetchRollupState(hash)
 	newState := CopyStateNoWithdrawals(parent)
-	return NewStateDb(s.db, hash, newState)
+	return NewStateDB(s.db, hash, newState)
 }
 
-func (s *storageImpl) GenesisStateDb() StateDb {
-	return NewStateDb(s.db, obscurocommon.GenesisHash, EmptyState())
+func (s *storageImpl) GenesisStateDB() StateDB {
+	return NewStateDB(s.db, obscurocommon.GenesisHash, EmptyState())
 }
 
 func (s *storageImpl) FetchHeadState() *BlockState {

--- a/go/obscuronode/enclave/db/types.go
+++ b/go/obscuronode/enclave/db/types.go
@@ -27,7 +27,6 @@ type State struct {
 type BlockState struct {
 	Block          *types.Block
 	Head           *core.Rollup
-	State          *State
 	FoundNewRollup bool
 }
 

--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -67,7 +67,7 @@ func (e *enclaveImpl) start(block types.Block) {
 	if f {
 		env.headRollup = blockState.Head
 		if env.headRollup != nil {
-			env.state = e.storage.CreateStateDb(env.headRollup.Hash())
+			env.state = e.storage.CreateStateDB(env.headRollup.Hash())
 		}
 	}
 
@@ -77,7 +77,7 @@ func (e *enclaveImpl) start(block types.Block) {
 		case winnerRollup := <-e.roundWinnerCh:
 			env.header = obscurocore.NewHeader(winnerRollup, winnerRollup.Header.Number+1, e.node)
 			env.headRollup = winnerRollup
-			env.state = e.storage.CreateStateDb(winnerRollup.Hash())
+			env.state = e.storage.CreateStateDB(winnerRollup.Hash())
 
 			// determine the transactions that were not yet included
 			env.processedTxs = currentTxs(winnerRollup, e.mempool.FetchMempoolTxs(), e.storage)
@@ -255,7 +255,7 @@ func (e *enclaveImpl) RoundWinner(parent obscurocommon.L2RootHash) (nodecommon.E
 		}
 	}
 
-	parentState := e.storage.CreateStateDb(head.Hash())
+	parentState := e.storage.CreateStateDB(head.Hash())
 	// determine the winner of the round
 	winnerRollup, s := e.findRoundWinner(usefulRollups, head, parentState, e.blockResolver, e.storage)
 	s.Commit(winnerRollup.Hash())
@@ -286,7 +286,7 @@ func (e *enclaveImpl) notifySpeculative(winnerRollup *obscurocore.Rollup) {
 
 func (e *enclaveImpl) Balance(address common.Address) uint64 {
 	// todo user encryption
-	return e.storage.CreateStateDb(e.storage.FetchHeadState().Head.Hash()).GetBalance(address)
+	return e.storage.CreateStateDB(e.storage.FetchHeadState().Head.Hash()).GetBalance(address)
 }
 
 func (e *enclaveImpl) produceRollup(b *types.Block, bs *db.BlockState) *obscurocore.Rollup {
@@ -317,7 +317,7 @@ func (e *enclaveImpl) produceRollup(b *types.Block, bs *db.BlockState) *obscuroc
 		// determine transactions to include in new rollup and process them
 		newRollupTxs = currentTxs(bs.Head, e.mempool.FetchMempoolTxs(), e.storage)
 
-		newRollupState = e.storage.CreateStateDb(bs.Head.Hash())
+		newRollupState = e.storage.CreateStateDB(bs.Head.Hash())
 		executeTransactions(newRollupTxs, newRollupState, newRollupHeader)
 	}
 
@@ -446,7 +446,7 @@ func encryptSecret(secret obscurocore.SharedEnclaveSecret) obscurocommon.Encrypt
 type speculativeWork struct {
 	found bool
 	r     *obscurocore.Rollup
-	s     db.StateDb
+	s     db.StateDB
 	h     *nodecommon.Header
 	txs   []nodecommon.L2Tx
 }
@@ -457,7 +457,7 @@ type processingEnvironment struct {
 	header          *nodecommon.Header              // the header of the new rollup
 	processedTxs    []nodecommon.L2Tx               // txs that were already processed
 	processedTxsMap map[common.Hash]nodecommon.L2Tx // structure used to prevent duplicates
-	state           db.StateDb                      // the state as calculated from the previous rollup and the processed transactions
+	state           db.StateDB                      // the state as calculated from the previous rollup and the processed transactions
 }
 
 // NewEnclave creates a new enclave.

--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -464,8 +464,8 @@ type processingEnvironment struct {
 // `genesisJSON` is the configuration for the corresponding L1's genesis block. This is used to validate the blocks
 // received from the L1 node if `validateBlocks` is set to true.
 func NewEnclave(id common.Address, mining bool, txHandler mgmtcontractlib.TxHandler, validateBlocks bool, genesisJSON []byte, collector StatsCollector) nodecommon.Enclave {
-	backingDb := db.NewInMemoryDB()
-	storage := db.NewStorage(backingDb)
+	backingDB := db.NewInMemoryDB()
+	storage := db.NewStorage(backingDB)
 
 	var l1Blockchain *core.BlockChain
 	if validateBlocks {

--- a/go/obscuronode/enclave/enclave.go
+++ b/go/obscuronode/enclave/enclave.go
@@ -67,7 +67,7 @@ func (e *enclaveImpl) start(block types.Block) {
 	if f {
 		env.headRollup = blockState.Head
 		if env.headRollup != nil {
-			env.state = db.CopyStateNoWithdrawals(e.storage.FetchRollupState(env.headRollup.Hash()))
+			env.state = e.storage.CreateStateDb(env.headRollup.Hash())
 		}
 	}
 
@@ -77,7 +77,7 @@ func (e *enclaveImpl) start(block types.Block) {
 		case winnerRollup := <-e.roundWinnerCh:
 			env.header = obscurocore.NewHeader(winnerRollup, winnerRollup.Header.Number+1, e.node)
 			env.headRollup = winnerRollup
-			env.state = db.CopyStateNoWithdrawals(e.storage.FetchRollupState(winnerRollup.Hash()))
+			env.state = e.storage.CreateStateDb(winnerRollup.Hash())
 
 			// determine the transactions that were not yet included
 			env.processedTxs = currentTxs(winnerRollup, e.mempool.FetchMempoolTxs(), e.storage)
@@ -103,11 +103,10 @@ func (e *enclaveImpl) start(block types.Block) {
 			} else {
 				b := make([]nodecommon.L2Tx, 0, len(env.processedTxs))
 				b = append(b, env.processedTxs...)
-				state := db.CopyState(env.state)
 				e.speculativeWorkOutCh <- speculativeWork{
 					found: true,
 					r:     env.headRollup,
-					s:     state,
+					s:     env.state.Copy(),
 					h:     env.header,
 					txs:   b,
 				}
@@ -149,7 +148,7 @@ func (e *enclaveImpl) IngestBlocks(blocks []*types.Block) []nodecommon.BlockSubm
 		}
 
 		e.storage.StoreBlock(block)
-		bs := updateState(block, e.blockResolver, e.storage, e.txHandler)
+		bs := updateState(block, e.blockResolver, e.txHandler, e.storage, e.storage)
 		if bs == nil {
 			result[i] = e.noBlockStateBlockSubmissionResponse(block)
 		} else {
@@ -191,7 +190,7 @@ func (e *enclaveImpl) SubmitBlock(block types.Block) nodecommon.BlockSubmissionR
 		return nodecommon.BlockSubmissionResponse{IngestedBlock: false}
 	}
 
-	blockState := updateState(&block, e.blockResolver, e.storage, e.txHandler)
+	blockState := updateState(&block, e.blockResolver, e.txHandler, e.storage, e.storage)
 	if blockState == nil {
 		return e.noBlockStateBlockSubmissionResponse(&block)
 	}
@@ -256,11 +255,11 @@ func (e *enclaveImpl) RoundWinner(parent obscurocommon.L2RootHash) (nodecommon.E
 		}
 	}
 
-	parentState := e.storage.FetchRollupState(head.Hash())
+	parentState := e.storage.CreateStateDb(head.Hash())
 	// determine the winner of the round
-	winnerRollup, s := e.findRoundWinner(usefulRollups, head, parentState, e.storage, e.blockResolver)
-
-	e.storage.SetRollupState(winnerRollup.Hash(), s)
+	winnerRollup, s := e.findRoundWinner(usefulRollups, head, parentState, e.blockResolver, e.storage)
+	s.Commit(winnerRollup.Hash())
+	// e.storage.SetRollupState(winnerRollup.Hash(), s)
 	go e.notifySpeculative(winnerRollup)
 
 	// we are the winner
@@ -287,7 +286,7 @@ func (e *enclaveImpl) notifySpeculative(winnerRollup *obscurocore.Rollup) {
 
 func (e *enclaveImpl) Balance(address common.Address) uint64 {
 	// todo user encryption
-	return e.storage.FetchHeadState().State.Balances[address]
+	return e.storage.CreateStateDb(e.storage.FetchHeadState().Head.Hash()).GetBalance(address)
 }
 
 func (e *enclaveImpl) produceRollup(b *types.Block, bs *db.BlockState) *obscurocore.Rollup {
@@ -318,7 +317,7 @@ func (e *enclaveImpl) produceRollup(b *types.Block, bs *db.BlockState) *obscuroc
 		// determine transactions to include in new rollup and process them
 		newRollupTxs = currentTxs(bs.Head, e.mempool.FetchMempoolTxs(), e.storage)
 
-		newRollupState = db.CopyStateNoWithdrawals(bs.State)
+		newRollupState = e.storage.CreateStateDb(bs.Head.Hash())
 		executeTransactions(newRollupTxs, newRollupState, newRollupHeader)
 	}
 
@@ -329,7 +328,7 @@ func (e *enclaveImpl) produceRollup(b *types.Block, bs *db.BlockState) *obscuroc
 	executeTransactions(depositTxs, newRollupState, newRollupHeader)
 
 	// Create a new rollup based on the proof of inclusion of the previous, including all new transactions
-	r := obscurocore.NewRollupFromHeader(newRollupHeader, b.Hash(), newRollupTxs, obscurocommon.GenerateNonce(), db.Serialize(newRollupState))
+	r := obscurocore.NewRollupFromHeader(newRollupHeader, b.Hash(), newRollupTxs, obscurocommon.GenerateNonce(), newRollupState.StateRoot())
 
 	// Postprocessing - withdrawals
 	r.Header.Withdrawals = rollupPostProcessingWithdrawals(&r, newRollupState)
@@ -447,7 +446,7 @@ func encryptSecret(secret obscurocore.SharedEnclaveSecret) obscurocommon.Encrypt
 type speculativeWork struct {
 	found bool
 	r     *obscurocore.Rollup
-	s     *db.State
+	s     db.StateDb
 	h     *nodecommon.Header
 	txs   []nodecommon.L2Tx
 }
@@ -458,14 +457,15 @@ type processingEnvironment struct {
 	header          *nodecommon.Header              // the header of the new rollup
 	processedTxs    []nodecommon.L2Tx               // txs that were already processed
 	processedTxsMap map[common.Hash]nodecommon.L2Tx // structure used to prevent duplicates
-	state           *db.State                       // the state as calculated from the previous rollup and the processed transactions
+	state           db.StateDb                      // the state as calculated from the previous rollup and the processed transactions
 }
 
 // NewEnclave creates a new enclave.
 // `genesisJSON` is the configuration for the corresponding L1's genesis block. This is used to validate the blocks
 // received from the L1 node if `validateBlocks` is set to true.
 func NewEnclave(id common.Address, mining bool, txHandler mgmtcontractlib.TxHandler, validateBlocks bool, genesisJSON []byte, collector StatsCollector) nodecommon.Enclave {
-	storage := db.NewStorage()
+	backingDb := db.NewInMemoryDB()
+	storage := db.NewStorage(backingDb)
 
 	var l1Blockchain *core.BlockChain
 	if validateBlocks {

--- a/go/obscuronode/enclave/state.go
+++ b/go/obscuronode/enclave/state.go
@@ -26,7 +26,7 @@ import (
 // todo - remove nolint after the header starts being used
 func executeTransactions(
 	txs []nodecommon.L2Tx,
-	s *db.State,
+	s db.StateDb,
 	header *nodecommon.Header, //nolint
 ) {
 	for _, tx := range txs {
@@ -36,7 +36,7 @@ func executeTransactions(
 }
 
 // mutates the state
-func executeTx(s *db.State, tx nodecommon.L2Tx) {
+func executeTx(s db.StateDb, tx nodecommon.L2Tx) {
 	switch core.TxData(&tx).Type {
 	case core.TransferTx:
 		executeTransfer(s, tx)
@@ -49,41 +49,43 @@ func executeTx(s *db.State, tx nodecommon.L2Tx) {
 	}
 }
 
-func executeWithdrawal(s *db.State, tx nodecommon.L2Tx) {
-	if txData := core.TxData(&tx); s.Balances[txData.From] >= txData.Amount {
-		s.Balances[txData.From] -= txData.Amount
-		s.Withdrawals = append(s.Withdrawals, tx.Hash())
+func executeWithdrawal(s db.StateDb, tx nodecommon.L2Tx) {
+	txData := core.TxData(&tx)
+	from := s.GetBalance(txData.From)
+	if from >= txData.Amount {
+		s.SetBalance(txData.From, from-txData.Amount)
+		s.AddWithdrawal(tx.Hash())
 	}
 }
 
-func executeTransfer(s *db.State, tx nodecommon.L2Tx) {
-	if txData := core.TxData(&tx); s.Balances[txData.From] >= txData.Amount {
-		s.Balances[txData.From] -= txData.Amount
-		s.Balances[txData.To] += txData.Amount
+func executeTransfer(s db.StateDb, tx nodecommon.L2Tx) {
+	txData := core.TxData(&tx)
+	from := s.GetBalance(txData.From)
+	to := s.GetBalance(txData.To)
+
+	if from >= txData.Amount {
+		s.SetBalance(txData.From, from-txData.Amount)
+		s.SetBalance(txData.To, to+txData.Amount)
 	}
 }
 
-func executeDeposit(s *db.State, tx nodecommon.L2Tx) {
-	t := core.TxData(&tx)
-	v, f := s.Balances[t.To]
-	if f {
-		s.Balances[t.To] = v + t.Amount
-	} else {
-		s.Balances[t.To] = t.Amount
-	}
+func executeDeposit(s db.StateDb, tx nodecommon.L2Tx) {
+	txData := core.TxData(&tx)
+	to := s.GetBalance(txData.To)
+	s.SetBalance(txData.To, to+txData.Amount)
 }
 
 // Determine the new canonical L2 head and calculate the State
 // Uses cache-ing to map the Head rollup and the State to each L1Node block.
-func updateState(b *types.Block, blockResolver db.BlockResolver, storage db.Storage, txHandler mgmtcontractlib.TxHandler) *db.BlockState {
+func updateState(b *types.Block, blockResolver db.BlockResolver, txHandler mgmtcontractlib.TxHandler, rollupResolver db.RollupResolver, bss db.BlockStateStorage) *db.BlockState {
 	// This method is called recursively in case of Re-orgs. Stop when state was calculated already.
-	val, found := storage.FetchBlockState(b.Hash())
+	val, found := bss.FetchBlockState(b.Hash())
 	if found {
 		return val
 	}
 
 	rollups := extractRollups(b, blockResolver, txHandler)
-	genesisRollup := storage.FetchGenesisRollup()
+	genesisRollup := rollupResolver.FetchGenesisRollup()
 
 	// processing blocks before genesis, so there is nothing to do
 	if genesisRollup == nil && len(rollups) == 0 {
@@ -92,22 +94,22 @@ func updateState(b *types.Block, blockResolver db.BlockResolver, storage db.Stor
 
 	// Detect if the incoming block contains the genesis rollup, and generate an updated state.
 	// Handle the case of the block containing the genesis being processed multiple times.
-	genesisState, isGenesis := handleGenesisRollup(b, storage, rollups, genesisRollup)
+	genesisState, isGenesis := handleGenesisRollup(b, rollups, genesisRollup, rollupResolver, bss)
 	if isGenesis {
 		return genesisState
 	}
 
 	// To calculate the state after the current block, we need the state after the parent.
 	// If this point is reached, there is a parent state guaranteed, because the genesis is handled above
-	parentState, parentFound := storage.FetchBlockState(b.ParentHash())
+	parentState, parentFound := bss.FetchBlockState(b.ParentHash())
 	if !parentFound {
 		// go back and calculate the State of the Parent
-		p, f := storage.FetchBlock(b.ParentHash())
+		p, f := blockResolver.FetchBlock(b.ParentHash())
 		if !f {
 			log.Log("Could not find block parent. This should not happen.")
 			return nil
 		}
-		parentState = updateState(p, blockResolver, storage, txHandler)
+		parentState = updateState(p, blockResolver, txHandler, rollupResolver, bss)
 	}
 
 	if parentState == nil {
@@ -119,14 +121,17 @@ func updateState(b *types.Block, blockResolver db.BlockResolver, storage db.Stor
 		return nil
 	}
 
-	bs := calculateBlockState(b, parentState, storage, blockResolver, rollups, txHandler)
+	bs, stateDb := calculateBlockState(b, parentState, blockResolver, rollups, txHandler, rollupResolver, bss)
 
-	storage.SetBlockState(b.Hash(), bs)
+	bss.SetBlockState(b.Hash(), bs)
+	if bs.FoundNewRollup {
+		stateDb.Commit(bs.Head.Hash())
+	}
 
 	return bs
 }
 
-func handleGenesisRollup(b *types.Block, s db.Storage, rollups []*core.Rollup, genesisRollup *core.Rollup) (genesisState *db.BlockState, isGenesis bool) {
+func handleGenesisRollup(b *types.Block, rollups []*core.Rollup, genesisRollup *core.Rollup, resolver db.RollupResolver, bss db.BlockStateStorage) (genesisState *db.BlockState, isGenesis bool) {
 	// the incoming block holds the genesis rollup
 	// calculate and return the new block state
 	// todo change this to an hardcoded hash on testnet/mainnet
@@ -134,16 +139,18 @@ func handleGenesisRollup(b *types.Block, s db.Storage, rollups []*core.Rollup, g
 		log.Log("Found genesis rollup")
 
 		genesis := rollups[0]
-		s.StoreGenesisRollup(genesis)
+		resolver.StoreGenesisRollup(genesis)
 
 		// The genesis rollup is part of the canonical chain and will be included in an L1 block by the first Aggregator.
 		bs := db.BlockState{
-			Block:          b,
-			Head:           genesis,
-			State:          db.EmptyState(),
+			Block: b,
+			Head:  genesis,
+			// State:          db.EmptyState(),
 			FoundNewRollup: true,
 		}
-		s.SetBlockState(b.Hash(), &bs)
+		bss.SetBlockState(b.Hash(), &bs)
+		state := bss.GenesisStateDb()
+		state.Commit(genesis.Hash())
 		return &bs, true
 	}
 
@@ -156,8 +163,8 @@ func handleGenesisRollup(b *types.Block, s db.Storage, rollups []*core.Rollup, g
 }
 
 // Calculate transactions to be included in the current rollup
-func currentTxs(head *core.Rollup, mempool []nodecommon.L2Tx, s db.Storage) []nodecommon.L2Tx {
-	return findTxsNotIncluded(head, mempool, s)
+func currentTxs(head *core.Rollup, mempool []nodecommon.L2Tx, resolver db.RollupResolver) []nodecommon.L2Tx {
+	return findTxsNotIncluded(head, mempool, resolver)
 }
 
 func FindWinner(parent *core.Rollup, rollups []*core.Rollup, blockResolver db.BlockResolver) (*core.Rollup, bool) {
@@ -182,30 +189,29 @@ func FindWinner(parent *core.Rollup, rollups []*core.Rollup, blockResolver db.Bl
 	return rollups[win], true
 }
 
-func (e *enclaveImpl) findRoundWinner(receivedRollups []*core.Rollup, parent *core.Rollup, parentState *db.State, s db.Storage, blockResolver db.BlockResolver) (*core.Rollup, *db.State) {
+func (e *enclaveImpl) findRoundWinner(receivedRollups []*core.Rollup, parent *core.Rollup, stateDb db.StateDb, blockResolver db.BlockResolver, rollupResolver db.RollupResolver) (*core.Rollup, db.StateDb) {
 	headRollup, found := FindWinner(parent, receivedRollups, blockResolver)
 	if !found {
 		panic("This should not happen for gossip rounds.")
 	}
 	// calculate the state to compare with what is in the Rollup
-	p := blockResolver.Proof(s.ParentRollup(headRollup))
+	p := blockResolver.Proof(rollupResolver.ParentRollup(headRollup))
 	depositTxs := processDeposits(p, blockResolver.Proof(headRollup), blockResolver, e.txHandler)
 
-	state := db.CopyStateNoWithdrawals(parentState)
-	executeTransactions(append(headRollup.Transactions, depositTxs...), state, headRollup.Header)
+	executeTransactions(append(headRollup.Transactions, depositTxs...), stateDb, headRollup.Header)
 
-	if db.Serialize(state) != headRollup.Header.State {
+	if stateDb.StateRoot() != headRollup.Header.State {
 		panic(fmt.Sprintf("Calculated a different state. This should not happen as there are no malicious actors yet. \nGot: %s\nExp: %s\nParent state:%v\nParent state:%s\nTxs:%v",
-			db.Serialize(state),
+			stateDb.StateRoot(),
 			headRollup.Header.State,
-			parentState,
+			stateDb,
 			parent.Header.State,
 			printTxs(headRollup.Transactions)),
 		)
 	}
 	// todo - check that the withdrawals in the header match the withdrawals as calculated
 
-	return headRollup, state
+	return headRollup, stateDb
 }
 
 // returns a list of L2 deposit transactions generated from the L1 deposit transactions
@@ -253,22 +259,22 @@ func processDeposits(fromBlock *types.Block, toBlock *types.Block, blockResolver
 }
 
 // given an L1 block, and the State as it was in the Parent block, calculates the State after the current block.
-func calculateBlockState(b *types.Block, parentState *db.BlockState, s db.Storage, blockResolver db.BlockResolver, rollups []*core.Rollup, txHandler mgmtcontractlib.TxHandler) *db.BlockState {
+func calculateBlockState(b *types.Block, parentState *db.BlockState, blockResolver db.BlockResolver, rollups []*core.Rollup, txHandler mgmtcontractlib.TxHandler, rollupResolver db.RollupResolver, bss db.BlockStateStorage) (*db.BlockState, db.StateDb) {
 	currentHead := parentState.Head
 	newHeadRollup, found := FindWinner(currentHead, rollups, blockResolver)
-	newState := parentState.State
+	stateDb := bss.CreateStateDb(parentState.Head.Hash())
 	// only change the state if there is a new l2 Head in the current block
 	if found {
 		// Preprocessing before passing to the vm
 		// todo transform into an eth block structure
-		parentRollup := s.ParentRollup(newHeadRollup)
+		parentRollup := rollupResolver.ParentRollup(newHeadRollup)
 		p := blockResolver.Proof(parentRollup)
 		depositTxs := processDeposits(p, blockResolver.Proof(newHeadRollup), blockResolver, txHandler)
 
 		// deposits have to be processed after the normal transactions were executed because during speculative execution they are not available
 		txsToProcess := append(newHeadRollup.Transactions, depositTxs...)
-		newState = db.CopyStateNoWithdrawals(parentState.State)
-		executeTransactions(txsToProcess, newState, newHeadRollup.Header)
+		executeTransactions(txsToProcess, stateDb, newHeadRollup.Header)
+		// todo - handle failure , which means a new winner must be selected
 	} else {
 		newHeadRollup = parentState.Head
 	}
@@ -276,19 +282,18 @@ func calculateBlockState(b *types.Block, parentState *db.BlockState, s db.Storag
 	bs := db.BlockState{
 		Block:          b,
 		Head:           newHeadRollup,
-		State:          newState,
 		FoundNewRollup: found,
 	}
-	return &bs
+	return &bs, stateDb
 }
 
 // Todo - this has to be implemented differently based on how we define the ObsERC20
-func rollupPostProcessingWithdrawals(newHeadRollup *core.Rollup, newState *db.State) []nodecommon.Withdrawal {
+func rollupPostProcessingWithdrawals(newHeadRollup *core.Rollup, state db.StateDb) []nodecommon.Withdrawal {
 	w := make([]nodecommon.Withdrawal, 0)
 	// go through each transaction and check if the withdrawal was processed correctly
 	for i, t := range newHeadRollup.Transactions {
 		txData := core.TxData(&newHeadRollup.Transactions[i])
-		if txData.Type == core.WithdrawalTx && contains(newState.Withdrawals, t.Hash()) {
+		if txData.Type == core.WithdrawalTx && contains(state.Withdrawals(), t.Hash()) {
 			w = append(w, nodecommon.Withdrawal{
 				Amount:  txData.Amount,
 				Address: txData.From,

--- a/go/obscuronode/enclave/utils.go
+++ b/go/obscuronode/enclave/utils.go
@@ -15,12 +15,12 @@ import (
 
 // findTxsNotIncluded - given a list of transactions, it keeps only the ones that were not included in the block
 // todo - inefficient
-func findTxsNotIncluded(head *core.Rollup, txs []nodecommon.L2Tx, s db.Storage) []nodecommon.L2Tx {
+func findTxsNotIncluded(head *core.Rollup, txs []nodecommon.L2Tx, s db.RollupResolver) []nodecommon.L2Tx {
 	included := allIncludedTransactions(head, s)
 	return removeExisting(txs, included)
 }
 
-func allIncludedTransactions(b *core.Rollup, s db.Storage) map[common.Hash]nodecommon.L2Tx {
+func allIncludedTransactions(b *core.Rollup, s db.RollupResolver) map[common.Hash]nodecommon.L2Tx {
 	val, found := s.FetchRollupTxs(b)
 	if found {
 		return val


### PR DESCRIPTION
Introduce a per-block database with a similar lifecycle to the evm statedb.

Note: This work is just a step towards the final goal, so it's quite unpolished.