### PR TITLE
Improve logging, fix geth test

### DIFF
--- a/go/ethclient/mgmtcontractlib/handler.go
+++ b/go/ethclient/mgmtcontractlib/handler.go
@@ -57,7 +57,7 @@ func (h *mgmtContractTxHandler) PackTx(tx *obscurocommon.L1TxData, fromAddr comm
 			panic(err)
 		}
 		ethTx.Data = data
-		log.Log(fmt.Sprintf("Broadcasting - Issuing DepositTx - Addr: %s deposited %d to %s ",
+		log.Log(fmt.Sprintf("- Broadcasting - Issuing DepositTx - Addr: %s deposited %d to %s ",
 			fromAddr, tx.Amount, tx.Dest))
 
 	case obscurocommon.RollupTx:
@@ -76,7 +76,8 @@ func (h *mgmtContractTxHandler) PackTx(tx *obscurocommon.L1TxData, fromAddr comm
 		}
 
 		ethTx.Data = data
-		log.Log(fmt.Sprintf("Broadcasting - Issuing Rollup: %s - %d txs - datasize: %d - gas: %d \n", r.Hash(), len(r.Transactions), len(data), ethTx.Gas))
+		log.Log(fmt.Sprintf("- Broadcasting - Issuing Rollup: r_%d - %d txs - datasize: %d - gas: %d",
+			obscurocommon.ShortHash(r.Hash()), len(r.Transactions), len(data), ethTx.Gas))
 
 	case obscurocommon.StoreSecretTx:
 		data, err := contracts.MgmtContractABIJSON.Pack(contracts.StoreSecretMethod, EncodeToString(tx.Secret))
@@ -84,14 +85,14 @@ func (h *mgmtContractTxHandler) PackTx(tx *obscurocommon.L1TxData, fromAddr comm
 			panic(err)
 		}
 		ethTx.Data = data
-		log.Log(fmt.Sprintf("Broadcasting - Issuing StoreSecretTx: encoded as %s", EncodeToString(tx.Secret)))
+		log.Log(fmt.Sprintf("- Broadcasting - Issuing StoreSecretTx: encoded as %s", EncodeToString(tx.Secret)))
 	case obscurocommon.RequestSecretTx:
 		data, err := contracts.MgmtContractABIJSON.Pack(contracts.RequestSecretMethod)
 		if err != nil {
 			panic(err)
 		}
 		ethTx.Data = data
-		log.Log("Broadcasting - Issuing RequestSecret")
+		log.Log("- Broadcasting - Issuing RequestSecret")
 	}
 
 	return ethTx, nil

--- a/go/obscurocommon/utils.go
+++ b/go/obscurocommon/utils.go
@@ -110,7 +110,7 @@ func FindRollupDups(list []L2RootHash) map[L2RootHash]int {
 	for u, i := range elementCount {
 		if i > 1 {
 			dups[u] = i
-			fmt.Printf("Dup: %d\n", u)
+			fmt.Printf("Dup: r_%d\n", ShortHash(u))
 		}
 	}
 	return dups

--- a/go/obscuronode/enclave/db/storage.go
+++ b/go/obscuronode/enclave/db/storage.go
@@ -173,6 +173,9 @@ func (s *storageImpl) FetchBlockState(hash obscurocommon.L1RootHash) (*BlockStat
 }
 
 func (s *storageImpl) SetBlockState(hash obscurocommon.L1RootHash, state *BlockState) {
+	if state.Block.Hash() != hash {
+		panic("oops")
+	}
 	if state.FoundNewRollup {
 		s.db.SetBlockStateNewRollup(hash, state)
 	} else {

--- a/go/obscuronode/enclave/db/storage.go
+++ b/go/obscuronode/enclave/db/storage.go
@@ -174,7 +174,7 @@ func (s *storageImpl) FetchBlockState(hash obscurocommon.L1RootHash) (*BlockStat
 
 func (s *storageImpl) SetBlockState(hash obscurocommon.L1RootHash, state *BlockState) {
 	if state.Block.Hash() != hash {
-		panic("oops")
+		panic("Failed on a sanity check: `state.Block.Hash() != hash`")
 	}
 	if state.FoundNewRollup {
 		s.db.SetBlockStateNewRollup(hash, state)

--- a/go/obscuronode/enclave/state.go
+++ b/go/obscuronode/enclave/state.go
@@ -122,7 +122,11 @@ func updateState(b *types.Block, blockResolver db.BlockResolver, txHandler mgmtc
 	}
 
 	bs, stateDB := calculateBlockState(b, parentState, blockResolver, rollups, txHandler, rollupResolver, bss)
-
+	log.Log(fmt.Sprintf("- Calc block state b_%d: Found: %t - r_%d, ",
+		obscurocommon.ShortHash(b.Hash()),
+		bs.FoundNewRollup,
+		obscurocommon.ShortHash(bs.Head.Hash()),
+	))
 	bss.SetBlockState(b.Hash(), bs)
 	if bs.FoundNewRollup {
 		stateDB.Commit(bs.Head.Hash())
@@ -316,6 +320,10 @@ func extractRollups(b *types.Block, blockResolver db.BlockResolver, handler mgmt
 			// In case of L1 reorgs, rollups may end published on a fork
 			if blockResolver.IsBlockAncestor(b, r.Header.L1Proof) {
 				rollups = append(rollups, toEnclaveRollup(r))
+				log.Log(fmt.Sprintf("Extracted Rollup r_%d from block b_%d",
+					obscurocommon.ShortHash(r.Hash()),
+					obscurocommon.ShortHash(b.Hash()),
+				))
 			}
 		}
 	}

--- a/go/obscuronode/host/host.go
+++ b/go/obscuronode/host/host.go
@@ -378,20 +378,19 @@ func (a *Node) processBlocks(blocks []obscurocommon.EncodedBlock, interrupt *int
 }
 
 func (a *Node) handleRoundWinner(result nodecommon.BlockSubmissionResponse) func() {
-	resultCopy := result
 	return func() {
 		if atomic.LoadInt32(a.interrupt) == 1 {
 			return
 		}
 		// Request the round winner for the current head
-		winnerRollup, isWinner, err := a.Enclave.RoundWinner(resultCopy.ProducedRollup.Header.ParentHash)
+		winnerRollup, isWinner, err := a.Enclave.RoundWinner(result.ProducedRollup.Header.ParentHash)
 		if err != nil {
 			panic(err)
 		}
 		if isWinner {
 			log.Log(fmt.Sprintf(">   Agg%d: Winner (b_%d) r_%d(%d).",
 				obscurocommon.ShortAddress(a.ID),
-				obscurocommon.ShortHash(resultCopy.BlockHeader.Hash()),
+				obscurocommon.ShortHash(result.BlockHeader.Hash()),
 				obscurocommon.ShortHash(winnerRollup.Header.Hash()),
 				winnerRollup.Header.Number,
 			))

--- a/go/obscuronode/host/host.go
+++ b/go/obscuronode/host/host.go
@@ -255,7 +255,7 @@ func (a *Node) startProcessing() {
 			// TODO Enabling this without Request/RespondSecret will make non-genesis nodes ignore txs
 			if a.Enclave.IsInitialised() {
 				if err := a.Enclave.SubmitTx(tx); err != nil {
-					// log.Log(fmt.Sprintf(">   Agg%d: Could not submit transaction: %s", obscurocommon.ShortAddress(a.ID), err))
+					log.Log(fmt.Sprintf(">   Agg%d: Could not submit transaction: %s", obscurocommon.ShortAddress(a.ID), err))
 				}
 			}
 

--- a/go/obscuronode/nodecommon/encoding.go
+++ b/go/obscuronode/nodecommon/encoding.go
@@ -15,10 +15,10 @@ func EncodeRollup(r *Rollup) obscurocommon.EncodedRollup {
 }
 
 func DecodeRollup(encoded obscurocommon.EncodedRollup) (*Rollup, error) {
-	r := Rollup{}
-	err := rlp.DecodeBytes(encoded, &r)
+	r := new(Rollup)
+	err := rlp.DecodeBytes(encoded, r)
 
-	return &r, err
+	return r, err
 }
 
 func DecodeRollupOrPanic(rollup obscurocommon.EncodedRollup) *Rollup {

--- a/integration/gethnetwork/geth_network.go
+++ b/integration/gethnetwork/geth_network.go
@@ -116,6 +116,7 @@ func NewGethNetwork(portStart int, gethBinaryPath string, numNodes int, blockTim
 	buildDir := path.Join(buildDirBase, timestamp)
 	// We create a data directory for each node.
 	nodesDir, err := ioutil.TempDir("", timestamp)
+	fmt.Printf("Geth nodes created in: %s\n", nodesDir)
 	if err != nil {
 		panic(err)
 	}

--- a/integration/simulation/network/basicsocket.go
+++ b/integration/simulation/network/basicsocket.go
@@ -28,7 +28,7 @@ func NewBasicNetworkOfSocketNodes() Network {
 	return &basicNetworkOfSocketNodes{}
 }
 
-func (n *basicNetworkOfSocketNodes) Create(params params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []*host.Node, []string) {
+func (n *basicNetworkOfSocketNodes) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []*host.Node, []string) {
 	l1Clients := make([]ethclient.EthClient, params.NumberOfNodes)
 	n.ethNodes = make([]*ethereum_mock.Node, params.NumberOfNodes)
 	n.obscuroNodes = make([]*host.Node, params.NumberOfNodes)

--- a/integration/simulation/network/dockerenclave.go
+++ b/integration/simulation/network/dockerenclave.go
@@ -27,7 +27,7 @@ func NewBasicNetworkOfNodesWithDockerEnclave() Network {
 
 // Create initializes Obscuro nodes with their own Dockerised enclave servers that communicate with peers via sockets, wires them up, and populates the network objects
 // TODO - Use individual Docker containers for the Obscuro nodes and Ethereum nodes.
-func (n *basicNetworkOfNodesWithDockerEnclave) Create(params params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []*host.Node, []string) {
+func (n *basicNetworkOfNodesWithDockerEnclave) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []*host.Node, []string) {
 	l1Clients := make([]ethclient.EthClient, params.NumberOfNodes)
 	n.ethNodes = make([]*ethereum_mock.Node, params.NumberOfNodes)
 	n.obscuroNodes = make([]*host.Node, params.NumberOfNodes)

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -146,7 +146,7 @@ func deployContract(w wallet.Wallet, port uint) common.Address {
 	}
 
 	var receipt *types.Receipt
-	for start := time.Now(); time.Since(start) < 30*time.Second; time.Sleep(2 * time.Second) {
+	for start := time.Now(); time.Since(start) < 80*time.Second; time.Sleep(2 * time.Second) {
 		receipt, err = tmpClient.FetchTxReceipt(signedTx.Hash())
 		if err == nil && receipt != nil {
 			break

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -146,16 +146,12 @@ func deployContract(w wallet.Wallet, port uint) common.Address {
 	}
 
 	var receipt *types.Receipt
-	for start := time.Now(); time.Since(start) < 20*time.Second; time.Sleep(2 * time.Second) {
+	for start := time.Now(); time.Since(start) < 30*time.Second; time.Sleep(2 * time.Second) {
 		receipt, err = tmpClient.FetchTxReceipt(signedTx.Hash())
 		if err == nil && receipt != nil {
 			break
 		}
 		if !errors.Is(err, ethereum.NotFound) {
-			panic(err)
-		}
-		if receipt == nil {
-			fmt.Printf("Contract deploy failed. The receipt is null\n")
 			panic(err)
 		}
 		fmt.Printf("Contract deploy tx has not been mined into a block after %s...\n", time.Since(start))

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -154,6 +154,10 @@ func deployContract(w wallet.Wallet, port uint) common.Address {
 		if !errors.Is(err, ethereum.NotFound) {
 			panic(err)
 		}
+		if receipt == nil {
+			fmt.Printf("Contract deploy failed. The receipt is null\n")
+			panic(err)
+		}
 		fmt.Printf("Contract deploy tx has not been mined into a block after %s...\n", time.Since(start))
 	}
 

--- a/integration/simulation/network/geth_network.go
+++ b/integration/simulation/network/geth_network.go
@@ -1,8 +1,15 @@
 package network
 
 import (
+	"errors"
+	"fmt"
 	"math/big"
 	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/obscuronet/obscuro-playground/contracts"
+	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/obscuronet/obscuro-playground/go/ethclient"
@@ -19,14 +26,40 @@ type networkInMemGeth struct {
 	gethNetwork  *gethnetwork.GethNetwork
 }
 
-func NewNetworkInMemoryGeth(gethNetwork *gethnetwork.GethNetwork) Network {
-	return &networkInMemGeth{
-		gethNetwork: gethNetwork,
-	}
+func NewNetworkInMemoryGeth() Network {
+	return &networkInMemGeth{}
 }
 
 // Create inits and starts the nodes, wires them up, and populates the network objects
-func (n *networkInMemGeth) Create(params params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []*host.Node, []string) {
+func (n *networkInMemGeth) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []*host.Node, []string) {
+	// make sure the geth network binaries exist
+	path, err := gethnetwork.EnsureBinariesExist(gethnetwork.LatestVersion)
+	if err != nil {
+		panic(err)
+	}
+
+	// convert the wallets to strings
+	walletAddresses := make([]string, params.NumberOfObscuroWallets)
+	for i := 0; i < params.NumberOfObscuroWallets; i++ {
+		walletAddresses[i] = params.EthWallets[i].Address().String()
+	}
+
+	// kickoff the network with the prefunded wallet addresses
+	gn := gethnetwork.NewGethNetwork(
+		40000,
+		path,
+		params.NumberOfNodes,
+		int(params.AvgBlockDuration.Seconds()),
+		walletAddresses,
+	)
+	n.gethNetwork = &gn
+	// take the first random wallet and deploy the contract in the network
+	contractAddr := deployContract(params.EthWallets[0], gn.WebSocketPorts[0])
+
+	params.MgmtContractAddr = contractAddr
+	params.TxHandler = mgmtcontractlib.NewEthMgmtContractTxHandler(contractAddr)
+
+	// Create the obscuro node, each connected to a geth node
 	l1Clients := make([]ethclient.EthClient, params.NumberOfNodes)
 	n.obscuroNodes = make([]*host.Node, params.NumberOfNodes)
 
@@ -71,14 +104,19 @@ func (n *networkInMemGeth) Create(params params.SimParams, stats *stats.Stats) (
 	for _, m := range n.obscuroNodes {
 		t := m
 		go t.Start()
-		time.Sleep(params.AvgBlockDuration / 3)
+		time.Sleep(params.AvgBlockDuration / 10)
 	}
 
 	return l1Clients, n.obscuroNodes, nil
 }
 
 func (n *networkInMemGeth) TearDown() {
-	// Nop
+	go func() {
+		for _, n := range n.obscuroNodes {
+			n.Stop()
+		}
+	}()
+	n.gethNetwork.StopNodes()
 }
 
 func createEthClientConnection(id int64, port uint, wallet wallet.Wallet, contractAddr common.Address) ethclient.EthClient {
@@ -87,4 +125,38 @@ func createEthClientConnection(id int64, port uint, wallet wallet.Wallet, contra
 		panic(err)
 	}
 	return ethnode
+}
+
+func deployContract(w wallet.Wallet, port uint) common.Address {
+	tmpClient, err := ethclient.NewEthClient(common.Address{}, "127.0.0.1", port, w, common.Address{})
+	if err != nil {
+		panic(err)
+	}
+
+	deployContractTx := types.LegacyTx{
+		Nonce:    0, // relies on a clean env
+		GasPrice: big.NewInt(2000000000),
+		Gas:      1025_000_000,
+		Data:     common.Hex2Bytes(contracts.MgmtContractByteCode),
+	}
+
+	signedTx, err := tmpClient.SubmitTransaction(&deployContractTx)
+	if err != nil {
+		panic(err)
+	}
+
+	var receipt *types.Receipt
+	for start := time.Now(); time.Since(start) < 20*time.Second; time.Sleep(2 * time.Second) {
+		receipt, err = tmpClient.FetchTxReceipt(signedTx.Hash())
+		if err == nil && receipt != nil {
+			break
+		}
+		if !errors.Is(err, ethereum.NotFound) {
+			panic(err)
+		}
+		fmt.Printf("Contract deploy tx has not been mined into a block after %s...\n", time.Since(start))
+	}
+
+	fmt.Printf("Contract deployed to %s - using port %d\n", receipt.ContractAddress, port)
+	return receipt.ContractAddress
 }

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -26,7 +26,7 @@ func NewBasicNetworkOfInMemoryNodes() Network {
 }
 
 // Create inits and starts the nodes, wires them up, and populates the network objects
-func (n *basicNetworkOfInMemoryNodes) Create(params params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []*host.Node, []string) {
+func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []*host.Node, []string) {
 	l1Clients := make([]ethclient.EthClient, params.NumberOfNodes)
 	n.ethNodes = make([]*ethereum_mock.Node, params.NumberOfNodes)
 	n.obscuroNodes = make([]*host.Node, params.NumberOfNodes)

--- a/integration/simulation/network/network.go
+++ b/integration/simulation/network/network.go
@@ -16,6 +16,6 @@ import (
 type Network interface {
 	// Create - returns a group of started Ethereum nodes, a group of started Obscuro nodes, and the Obscuro nodes' P2P addresses.
 	// todo - return interfaces to RPC handles to the nodes
-	Create(params params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []*host.Node, []string)
+	Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []*host.Node, []string)
 	TearDown()
 }

--- a/integration/simulation/network/oneAzureEnclave.go
+++ b/integration/simulation/network/oneAzureEnclave.go
@@ -29,7 +29,7 @@ func NewNetworkWithOneAzureEnclave(enclaveAddress string) Network {
 	return &networkWithOneAzureEnclave{enclaveAddress: enclaveAddress}
 }
 
-func (n *networkWithOneAzureEnclave) Create(params params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []*host.Node, []string) {
+func (n *networkWithOneAzureEnclave) Create(params *params.SimParams, stats *stats.Stats) ([]ethclient.EthClient, []*host.Node, []string) {
 	l1Clients := make([]ethclient.EthClient, params.NumberOfNodes)
 	n.ethNodes = make([]*ethereum_mock.Node, params.NumberOfNodes)
 	n.obscuroNodes = make([]*host.Node, params.NumberOfNodes)

--- a/integration/simulation/params/params.go
+++ b/integration/simulation/params/params.go
@@ -24,8 +24,8 @@ type SimParams struct {
 	// dead blocks - Blocks that are produced and gossiped, but don't make it into the canonical chain.
 	// We test the results against this threshold to catch eventual protocol errors.
 	L1EfficiencyThreshold     float64
-	L2EfficiencyThreshold     float64
-	L2ToL1EfficiencyThreshold float64
+	L2EfficiencyThreshold     float64 // number of dead obscuro blocks
+	L2ToL1EfficiencyThreshold float64 // number of ethereum blocks that don't include an obscuro node
 
 	// TxHandler defines how the simulation should unpack transactions
 	TxHandler mgmtcontractlib.TxHandler

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -42,7 +42,7 @@ func (s *Simulation) Start() {
 	timer := time.Now()
 	go s.TxInjector.Start()
 
-	stoppingDelay := 7 * time.Second
+	stoppingDelay := s.Params.AvgBlockDuration * 4
 
 	// Wait for the simulation time
 	time.Sleep(s.SimulationTime - stoppingDelay)

--- a/integration/simulation/simulation_docker_test.go
+++ b/integration/simulation/simulation_docker_test.go
@@ -79,7 +79,7 @@ func TestDockerNodesMonteCarloSimulation(t *testing.T) {
 		}
 	}
 
-	testSimulation(t, network.NewBasicNetworkOfNodesWithDockerEnclave(), simParams)
+	testSimulation(t, network.NewBasicNetworkOfNodesWithDockerEnclave(), &simParams)
 }
 
 // Checks the required Docker images exist.

--- a/integration/simulation/simulation_geth_in_mem_test.go
+++ b/integration/simulation/simulation_geth_in_mem_test.go
@@ -1,20 +1,11 @@
 package simulation
 
 import (
-	"errors"
-	"math/big"
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/obscuro-playground/contracts"
-	"github.com/obscuronet/obscuro-playground/go/ethclient"
-	"github.com/obscuronet/obscuro-playground/go/ethclient/mgmtcontractlib"
 	"github.com/obscuronet/obscuro-playground/go/ethclient/wallet"
 	"github.com/obscuronet/obscuro-playground/integration/datagenerator"
-	"github.com/obscuronet/obscuro-playground/integration/gethnetwork"
 	"github.com/obscuronet/obscuro-playground/integration/simulation/network"
 	"github.com/obscuronet/obscuro-playground/integration/simulation/params"
 )
@@ -25,82 +16,28 @@ func TestGethMemObscuroEthMonteCarloSimulation(t *testing.T) {
 
 	numberOfNodes := 5
 
+	// there is one wallet per node, so there have to be at least numberOfNodes wallets available
+	numberOfWallets := numberOfNodes
+
 	// randomly create the ethereum wallets to be used and prefund them
-	wallets := make([]wallet.Wallet, numberOfNodes)
-	walletAddresses := make([]string, numberOfNodes)
-	for i := 0; i < numberOfNodes; i++ {
+	wallets := make([]wallet.Wallet, numberOfWallets)
+	for i := 0; i < numberOfWallets; i++ {
 		wallets[i] = datagenerator.RandomWallet()
-		walletAddresses[i] = wallets[i].Address().String()
 	}
 
-	// make sure the network binaries exist
-	path, err := gethnetwork.EnsureBinariesExist(gethnetwork.LatestVersion)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// kickoff the network with the prefunded wallet addresses
-	gethNetwork := gethnetwork.NewGethNetwork(
-		40000,
-		path,
-		numberOfNodes,
-		1,
-		walletAddresses,
-	)
-	defer gethNetwork.StopNodes()
-
-	// take the first random wallet and deploy the contract in the network
-	contractAddr := deployContract(t, wallets[0], gethNetwork.WebSocketPorts[0])
-
-	params := params.SimParams{
+	simParams := params.SimParams{
 		NumberOfNodes:             numberOfNodes,
-		NumberOfObscuroWallets:    10,
-		AvgBlockDuration:          time.Second,
-		SimulationTime:            25 * time.Second,
+		NumberOfObscuroWallets:    numberOfWallets,
+		AvgBlockDuration:          6 * time.Second,
+		SimulationTime:            60 * time.Second,
 		L1EfficiencyThreshold:     0.2,
 		L2EfficiencyThreshold:     0.5,
-		L2ToL1EfficiencyThreshold: 0.9,
-		TxHandler:                 mgmtcontractlib.NewEthMgmtContractTxHandler(contractAddr),
-		MgmtContractAddr:          contractAddr,
+		L2ToL1EfficiencyThreshold: 0.4,
 		EthWallets:                wallets,
 	}
 
-	params.AvgNetworkLatency = params.AvgBlockDuration / 50
-	params.AvgGossipPeriod = params.AvgBlockDuration / 3
+	simParams.AvgNetworkLatency = simParams.AvgBlockDuration / 15
+	simParams.AvgGossipPeriod = simParams.AvgBlockDuration / 3
 
-	testSimulation(t, network.NewNetworkInMemoryGeth(&gethNetwork), params)
-}
-
-func deployContract(t *testing.T, w wallet.Wallet, port uint) common.Address {
-	tmpClient, err := ethclient.NewEthClient(common.Address{}, "127.0.0.1", port, w, common.Address{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	deployContractTx := types.LegacyTx{
-		Nonce:    0, // relies on a clean env
-		GasPrice: big.NewInt(2000000000),
-		Gas:      1025_000_000,
-		Data:     common.Hex2Bytes(contracts.MgmtContractByteCode),
-	}
-
-	signedTx, err := tmpClient.SubmitTransaction(&deployContractTx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var receipt *types.Receipt
-	for start := time.Now(); time.Since(start) < 10*time.Second; time.Sleep(time.Second) {
-		receipt, err = tmpClient.FetchTxReceipt(signedTx.Hash())
-		if err == nil && receipt != nil {
-			break
-		}
-		if !errors.Is(err, ethereum.NotFound) {
-			t.Fatal(err)
-		}
-		t.Logf("Contract deploy tx has not been mined into a block after %s...", time.Since(start))
-	}
-
-	t.Logf("Contract deployed to %s - using port %d\n", receipt.ContractAddress, port)
-	return receipt.ContractAddress
+	testSimulation(t, network.NewNetworkInMemoryGeth(), &simParams)
 }

--- a/integration/simulation/simulation_in_mem_test.go
+++ b/integration/simulation/simulation_in_mem_test.go
@@ -33,5 +33,5 @@ func TestInMemoryMonteCarloSimulation(t *testing.T) {
 	simParams.AvgNetworkLatency = simParams.AvgBlockDuration / 15
 	simParams.AvgGossipPeriod = simParams.AvgBlockDuration * 2 / 7
 
-	testSimulation(t, network.NewBasicNetworkOfInMemoryNodes(), simParams)
+	testSimulation(t, network.NewBasicNetworkOfInMemoryNodes(), &simParams)
 }

--- a/integration/simulation/simulation_socket_test.go
+++ b/integration/simulation/simulation_socket_test.go
@@ -30,5 +30,5 @@ func TestSocketNodesMonteCarloSimulation(t *testing.T) {
 	simParams.AvgNetworkLatency = simParams.AvgBlockDuration / 15
 	simParams.AvgGossipPeriod = simParams.AvgBlockDuration / 4
 
-	testSimulation(t, network.NewBasicNetworkOfSocketNodes(), simParams)
+	testSimulation(t, network.NewBasicNetworkOfSocketNodes(), &simParams)
 }

--- a/integration/simulation/simulation_tester.go
+++ b/integration/simulation/simulation_tester.go
@@ -1,13 +1,9 @@
 package simulation
 
 import (
-	"fmt"
 	"math/rand"
 	"testing"
 	"time"
-
-	"github.com/obscuronet/obscuro-playground/go/obscurocommon"
-	"github.com/obscuronet/obscuro-playground/go/obscuronode/host"
 
 	"github.com/obscuronet/obscuro-playground/integration/simulation/network"
 	"github.com/obscuronet/obscuro-playground/integration/simulation/params"
@@ -18,7 +14,7 @@ import (
 )
 
 // testSimulation encapsulates the shared logic for simulating and testing various types of nodes.
-func testSimulation(t *testing.T, netw network.Network, params params.SimParams) {
+func testSimulation(t *testing.T, netw network.Network, params *params.SimParams) {
 	rand.Seed(time.Now().UnixNano())
 	uuid.EnableRandPool()
 
@@ -36,10 +32,8 @@ func testSimulation(t *testing.T, netw network.Network, params params.SimParams)
 		TxInjector:       txInjector,
 		SimulationTime:   params.SimulationTime,
 		Stats:            stats,
-		Params:           &params,
+		Params:           params,
 	}
-
-	waitForNodesReady(obscuroNodes)
 
 	// execute the simulation
 	simulation.Start()
@@ -52,18 +46,4 @@ func testSimulation(t *testing.T, netw network.Network, params params.SimParams)
 	// generate and print the final stats
 	t.Logf("Simulation results:%+v", NewOutputStats(&simulation))
 	netw.TearDown()
-}
-
-func waitForNodesReady(obsNodes []*host.Node) {
-	now := time.Now()
-	for _, n := range obsNodes {
-		for {
-			if n.IsReady() {
-				fmt.Printf("Node %d is Ready after %s\n", obscurocommon.ShortAddress(n.ID), time.Since(now))
-				break
-			}
-			fmt.Printf("Waiting on Node %d after %s \n", obscurocommon.ShortAddress(n.ID), time.Since(now))
-			time.Sleep(100 * time.Millisecond)
-		}
-	}
 }


### PR DESCRIPTION
This PR is a result of debugging the very flaky geth test:
- made the logging consistent and easy to follow.
- slightly refactored the geth test according to the general pattern, and fix the duration 
- tweak the parameters of geth, as it turns out it takes a few seconds to publish a transaction
