### PR TITLE
Prevents test failure if wallet extension is connected too soon.

### DIFF
--- a/tools/walletextension/wallet_extension_test.go
+++ b/tools/walletextension/wallet_extension_test.go
@@ -232,7 +232,10 @@ func TestCannotCallForAnotherAddressAfterSubmittingViewingKey(t *testing.T) {
 func waitForWalletExtension(t *testing.T, walletExtensionAddr string) {
 	retries := 10
 	for i := 0; i < retries; i++ {
-		_, err := http.Get(walletExtensionAddr)
+		resp, err := http.Get(walletExtensionAddr) //nolint:gosec,noctx
+		if resp != nil && resp.Body != nil {
+			resp.Body.Close()
+		}
 		if err != nil {
 			return
 		}

--- a/tools/walletextension/wallet_extension_test.go
+++ b/tools/walletextension/wallet_extension_test.go
@@ -236,7 +236,7 @@ func waitForWalletExtension(t *testing.T, walletExtensionAddr string) {
 		if resp != nil && resp.Body != nil {
 			resp.Body.Close()
 		}
-		if err != nil {
+		if err == nil {
 			return
 		}
 		time.Sleep(300 * time.Millisecond)


### PR DESCRIPTION
Previously, there was a race condition whereby the wallet extension tests could fire off a request before the wallet extension had opened its port. We add a retry to prevent this causing a test failure.